### PR TITLE
Remove default border radius

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -406,11 +406,6 @@
 					}
 				}
 			},
-			"core/image": {
-				"border": {
-					"radius": "16px"
-				}
-			},
 			"core/list": {
 				"spacing": {
 					"padding": {


### PR DESCRIPTION
Removes the default border radius from the theme.json file for the image block.