### PR TITLE
Add translation strings to "columns" pattern 

### DIFF
--- a/patterns/columns.php
+++ b/patterns/columns.php
@@ -3,76 +3,86 @@
  * Title: Columns
  * Slug: twentytwentyfour/columns
  * Categories: text
-
  */
 
 ?>
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"7em","right":"7em","bottom":"7em","left":"7em"}}},"backgroundColor":"base","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-base-background-color has-background" style="padding-top:7em;padding-right:7em;padding-bottom:7em;padding-left:7em"><!-- wp:columns {"align":"wide"} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"width":"33%","style":{"spacing":{"blockGap":"","padding":{"right":"12%"}}}} -->
-<div class="wp-block-column" style="padding-right:12%;flex-basis:33%"><!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading">
-    <?php echo esc_html__( 'We recognize the crucial role architecture plays in shaping a sustainable future.', 'twentytwentyfour' ); ?>
-</h3>
-<!-- /wp:heading --></div>
-<!-- /wp:column -->
+<div class="wp-block-group alignfull has-base-background-color has-background"
+     style="padding-top:7em;padding-right:7em;padding-bottom:7em;padding-left:7em"><!-- wp:columns {"align":"wide"} -->
+    <div class="wp-block-columns alignwide">
+        <!-- wp:column {"width":"33%","style":{"spacing":{"blockGap":"","padding":{"right":"12%"}}}} -->
+        <div class="wp-block-column" style="padding-right:12%;flex-basis:33%"><!-- wp:heading {"level":3} -->
+            <h3 class="wp-block-heading">
+                <?php echo esc_html__('We recognize the crucial role architecture plays in shaping a sustainable future.', 'twentytwentyfour'); ?>
+            </h3>
+            <!-- /wp:heading --></div>
+        <!-- /wp:column -->
 
-<!-- wp:column {"style":{"spacing":{"blockGap":"5.6em"}}} -->
-<div class="wp-block-column"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
-<div class="wp-block-group"><!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
-<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">
-    <?php echo esc_html__( 'Consulting', 'twentytwentyfour' ); ?>
-</h4>
-<!-- /wp:heading -->
+        <!-- wp:column {"style":{"spacing":{"blockGap":"5.6em"}}} -->
+        <div class="wp-block-column"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+            <div class="wp-block-group">
+                <!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
+                <div class="wp-block-group">
+                    <!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
+                    <h4 class="wp-block-heading has-system-font-font-family has-medium-font-size"
+                        style="font-style:normal;font-weight:700;line-height:1.1">
+                        <?php echo esc_html__('Consulting', 'twentytwentyfour'); ?>
+                    </h4>
+                    <!-- /wp:heading -->
 
-<!-- wp:paragraph -->
-<p><?php echo esc_html__( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->
+                    <!-- wp:paragraph -->
+                    <p><?php echo esc_html__('Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour'); ?></p>
+                    <!-- /wp:paragraph --></div>
+                <!-- /wp:group -->
 
-<!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
-<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">
-    <?php echo esc_html__( 'Project Management', 'twentytwentyfour' ); ?>
-</h4>
-<!-- /wp:heading -->
+                <!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
+                <div class="wp-block-group">
+                    <!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
+                    <h4 class="wp-block-heading has-system-font-font-family has-medium-font-size"
+                        style="font-style:normal;font-weight:700;line-height:1.1">
+                        <?php echo esc_html__('Project Management', 'twentytwentyfour'); ?>
+                    </h4>
+                    <!-- /wp:heading -->
 
-<!-- wp:paragraph -->
-<p><?php echo esc_html__( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of
-    architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
+                    <!-- wp:paragraph -->
+                    <p><?php echo esc_html__('Our vision is to be at the forefront of architectural innovation, fostering a global community of
+    architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour'); ?></p>
+                    <!-- /wp:paragraph --></div>
+                <!-- /wp:group --></div>
+            <!-- /wp:group -->
 
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
-<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">
-    <?php echo esc_html__( 'Design', 'twentytwentyfour' ); ?>
-</h4>
-<!-- /wp:heading -->
+            <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+            <div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
+                <div class="wp-block-group">
+                    <!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
+                    <h4 class="wp-block-heading has-system-font-font-family has-medium-font-size"
+                        style="font-style:normal;font-weight:700;line-height:1.1">
+                        <?php echo esc_html__('Design', 'twentytwentyfour'); ?>
+                    </h4>
+                    <!-- /wp:heading -->
 
-<!-- wp:paragraph -->
-<p><?php echo esc_html__( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of
-    architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->
+                    <!-- wp:paragraph -->
+                    <p><?php echo esc_html__('Our vision is to be at the forefront of architectural innovation, fostering a global community of
+    architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour'); ?></p>
+                    <!-- /wp:paragraph --></div>
+                <!-- /wp:group -->
 
-<!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
-<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">
-    <?php echo esc_html__( 'Maintenance', 'twentytwentyfour' ); ?>
-</h4>
-<!-- /wp:heading -->
+                <!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
+                <div class="wp-block-group">
+                    <!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
+                    <h4 class="wp-block-heading has-system-font-font-family has-medium-font-size"
+                        style="font-style:normal;font-weight:700;line-height:1.1">
+                        <?php echo esc_html__('Maintenance', 'twentytwentyfour'); ?>
+                    </h4>
+                    <!-- /wp:heading -->
 
-<!-- wp:paragraph -->
-<p><?php echo esc_html__( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of
-    architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
+                    <!-- wp:paragraph -->
+                    <p><?php echo esc_html__('Our vision is to be at the forefront of architectural innovation, fostering a global community of
+    architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour'); ?></p>
+                    <!-- /wp:paragraph --></div>
+                <!-- /wp:group --></div>
+            <!-- /wp:group --></div>
+        <!-- /wp:column --></div>
+    <!-- /wp:columns --></div>
 <!-- /wp:group -->

--- a/patterns/columns.php
+++ b/patterns/columns.php
@@ -12,7 +12,9 @@
 <div class="wp-block-group alignfull has-base-background-color has-background" style="padding-top:7em;padding-right:7em;padding-bottom:7em;padding-left:7em"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"33%","style":{"spacing":{"blockGap":"","padding":{"right":"12%"}}}} -->
 <div class="wp-block-column" style="padding-right:12%;flex-basis:33%"><!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading">We recognize the crucial role architecture plays in shaping a sustainable future.</h3>
+<h3 class="wp-block-heading">
+    <?php echo esc_html__( 'We recognize the crucial role architecture plays in shaping a sustainable future.', 'twentytwentyfour' ); ?>
+</h3>
 <!-- /wp:heading --></div>
 <!-- /wp:column -->
 
@@ -20,21 +22,26 @@
 <div class="wp-block-column"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
 <div class="wp-block-group"><!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
-<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">Consulting</h4>
+<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">
+    <?php echo esc_html__( 'Consulting', 'twentytwentyfour' ); ?>
+</h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.</p>
+<p><?php echo esc_html__( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
-<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">Project Management</h4>
+<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">
+    <?php echo esc_html__( 'Project Management', 'twentytwentyfour' ); ?>
+</h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.</p>
+<p><?php echo esc_html__( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of
+    architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
@@ -42,21 +49,27 @@
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
-<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">Design</h4>
+<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">
+    <?php echo esc_html__( 'Design', 'twentytwentyfour' ); ?>
+</h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.</p>
+<p><?php echo esc_html__( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of
+    architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
-<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">Maintenance</h4>
+<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">
+    <?php echo esc_html__( 'Maintenance', 'twentytwentyfour' ); ?>
+</h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.</p>
+<p><?php echo esc_html__( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of
+    architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>


### PR DESCRIPTION
This addresses issue #37 and adds translation functions to text in the columns pattern.

Normally at Kanopi we enforce certain standards and formatting, especially line lengths, so I broke some content for that reason. Can adjust if needed.