### PR TITLE
Add translation strings to "Home" pattern, escape it and adds indentation for code

### DIFF
--- a/patterns/home.php
+++ b/patterns/home.php
@@ -11,18 +11,18 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|80"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--80)">
 		<!-- wp:heading {"textAlign":"center"} -->
-		<h2 class="wp-block-heading has-text-align-center">A commitment to innovation and sustainability</h2>
+		<h2 class="wp-block-heading has-text-align-center"><?php esc_html_e( 'A commitment to innovation and sustainability', 'twentytwentyfour' ); ?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}}},"fontSize":"small"} -->
-		<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0">Études is a pioneering firm that seamlessly merges creativity and functionality to redefine architectural excellence.</p>
+		<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0"><?php esc_html_e( 'Études is a pioneering firm that seamlessly merges creativity and functionality to redefine architectural excellence.', 'twentytwentyfour' ); ?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 		<div class="wp-block-buttons">
 			<!-- wp:button -->
 			<div class="wp-block-button">
-				<a class="wp-block-button__link wp-element-button">Learn More</a>
+				<a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Learn More', 'twentytwentyfour' ); ?></a>
 			</div>
 			<!-- /wp:button -->
 		</div>
@@ -31,7 +31,9 @@
 	<!-- /wp:group -->
 
 	<!-- wp:image {"align":"wide","id":369,"sizeSlug":"full","linkDestination":"none"} -->
-	<figure class="wp-block-image alignwide size-full"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/tt4_business_image_hero.jpg" alt="" class="wp-image-369"/></figure>
+	<figure class="wp-block-image alignwide size-full">
+		<img src="<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/images/tt4_business_image_hero.jpg' ); ?>" alt="" class="wp-image-369"/>
+	</figure>
 	<!-- /wp:image -->
 </div>
 <!-- /wp:group -->
@@ -45,11 +47,11 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 	<div class="wp-block-group">
 		<!-- wp:heading {"textAlign":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast"} -->
-		<h2 class="wp-block-heading has-text-align-center has-contrast-color has-text-color has-link-color">A passion for creating spaces</h2>
+		<h2 class="wp-block-heading has-text-align-center has-contrast-color has-text-color has-link-color"><?php esc_html_e( 'A passion for creating spaces', 'twentytwentyfour' ); ?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}}},"fontSize":"small"} -->
-		<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0">Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.</p>
+		<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0"><?php esc_html_e( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.', 'twentytwentyfour' ); ?></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->
@@ -69,11 +71,11 @@
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-				<p class="has-text-align-center has-small-font-size"><strong>Consulting</strong></p>
+				<p class="has-text-align-center has-small-font-size"><strong><?php esc_html_e( 'Consulting', 'twentytwentyfour' ); ?></strong></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"left"} -->
-				<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+				<p class="has-text-align-left"><?php esc_html_e( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
@@ -89,11 +91,11 @@
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-				<p class="has-text-align-center has-small-font-size"><strong>Project Management</strong></p>
+				<p class="has-text-align-center has-small-font-size"><strong><?php esc_html_e( 'Project Management', 'twentytwentyfour' ); ?></strong></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"left"} -->
-				<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+				<p class="has-text-align-left"><?php esc_html_e( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
@@ -109,11 +111,11 @@
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-				<p class="has-text-align-center has-small-font-size"><strong>Architectural Solutions</strong></p>
+				<p class="has-text-align-center has-small-font-size"><strong><?php esc_html_e( 'Architectural Solutions', 'twentytwentyfour' ); ?></strong></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"left"} -->
-				<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+				<p class="has-text-align-left"><?php esc_html_e( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
@@ -133,11 +135,11 @@
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-				<p class="has-text-align-center has-small-font-size"><strong>Renovation and restoration</strong></p>
+				<p class="has-text-align-center has-small-font-size"><strong><?php esc_html_e( 'Renovation and restoration', 'twentytwentyfour' ); ?></strong></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"left"} -->
-				<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+				<p class="has-text-align-left"><?php esc_html_e( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
@@ -153,11 +155,11 @@
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-				<p class="has-text-align-center has-small-font-size"><strong>Continuous Support</strong></p>
+				<p class="has-text-align-center has-small-font-size"><strong><?php esc_html_e( 'Continuous Support', 'twentytwentyfour' ); ?></strong></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"left"} -->
-				<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+				<p class="has-text-align-left"><?php esc_html_e( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
@@ -173,11 +175,11 @@
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-				<p class="has-text-align-center has-small-font-size"><strong>App Access</strong></p>
+				<p class="has-text-align-center has-small-font-size"><strong><?php esc_html_e( 'App Access', 'twentytwentyfour' ); ?></strong></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"left"} -->
-				<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+				<p class="has-text-align-left"><?php esc_html_e( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
@@ -197,11 +199,11 @@
 		<!-- /wp:paragraph -->
 
 		<!-- wp:heading {"textAlign":"center"} -->
-		<h2 class="wp-block-heading has-text-align-center">An array of resources</h2>
+		<h2 class="wp-block-heading has-text-align-center"><?php esc_html_e( 'An array of resources', 'twentytwentyfour' ); ?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}}},"fontSize":"small"} -->
-		<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0">Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.</p>
+		<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0"><?php esc_html_e( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.', 'twentytwentyfour' ); ?></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->
@@ -221,7 +223,7 @@
 				<!-- /wp:paragraph -->
 
 				<!-- wp:heading {"level":3,"fontSize":"large"} -->
-				<h3 class="wp-block-heading has-large-font-size">Études Architect App</h3>
+				<h3 class="wp-block-heading has-large-font-size"><?php esc_html_e( 'Études Architect App', 'twentytwentyfour' ); ?></h3>
 				<!-- /wp:heading -->
 			</div>
 			<!-- /wp:group -->
@@ -229,15 +231,15 @@
 			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 			<div class="wp-block-group">
 				<!-- wp:paragraph -->
-				<p><strong>✓</strong> Collaborate with fellow architects</p>
+				<p><strong>✓</strong> <?php esc_html_e( 'Collaborate with fellow architects', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph -->
-				<p><strong>✓</strong> Showcase your projects</p>
+				<p><strong>✓</strong> <?php esc_html_e( 'Showcase your projects', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph -->
-				<p><strong>✓</strong> Experience the world of architecture like never before</p>
+				<p><strong>✓</strong> <?php esc_html_e( 'Experience the world of architecture like never before', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
@@ -248,7 +250,7 @@
 		<div class="wp-block-column">
 			<!-- wp:image {"id":370,"sizeSlug":"large","linkDestination":"none"} -->
 			<figure class="wp-block-image size-large">
-				<img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/tt4_business_image_app.jpg" alt="" class="wp-image-370"/>
+				<img src="<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/images/tt4_business_image_app.jpg' ); ?>" alt="" class="wp-image-370"/>
 			</figure>
 			<!-- /wp:image -->
 		</div>
@@ -266,7 +268,7 @@
 		<div class="wp-block-column">
 			<!-- wp:image {"id":67,"sizeSlug":"large","linkDestination":"none"} -->
 			<figure class="wp-block-image size-large">
-				<img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/tt4_home_image-2.jpg" alt="" class="wp-image-67"/>
+				<img src="<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/images/tt4_home_image-2.jpg' ); ?>" alt="" class="wp-image-67"/>
 			</figure>
 			<!-- /wp:image -->
 		</div>
@@ -281,7 +283,7 @@
 				<!-- /wp:paragraph -->
 
 				<!-- wp:heading {"level":3,"fontSize":"large"} -->
-				<h3 class="wp-block-heading has-large-font-size">Études Newsletter</h3>
+				<h3 class="wp-block-heading has-large-font-size"><?php esc_html_e( 'Études Newsletter', 'twentytwentyfour' ); ?></h3>
 				<!-- /wp:heading -->
 			</div>
 			<!-- /wp:group -->
@@ -289,15 +291,15 @@
 			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 			<div class="wp-block-group">
 				<!-- wp:paragraph -->
-				<p><strong>✓</strong> Dive into a world of thought-provoking articles</p>
+				<p><strong>✓</strong> <?php esc_html_e( 'Dive into a world of thought-provoking articles', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph -->
-				<p><strong>✓</strong> Read case studies that celebrate the artistry of architecture</p>
+				<p><strong>✓</strong> <?php esc_html_e( 'Read case studies that celebrate the artistry of architecture', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph -->
-				<p><strong>✓</strong> Gain exclusive access to design insights</p>
+				<p><strong>✓</strong> <?php esc_html_e( 'Gain exclusive access to design insights', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
@@ -313,7 +315,7 @@
 	<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-group alignwide">
 		<!-- wp:paragraph {"align":"center","style":{"typography":{"lineHeight":"1.2","letterSpacing":"-0.02em"}},"fontSize":"x-large","fontFamily":"cardo"} -->
-		<p class="has-text-align-center has-cardo-font-family has-x-large-font-size" style="letter-spacing:-0.02em;line-height:1.2"><em>“Études has saved us thousands of hours of work and has unlocked insights we never thought possible.”</em></p>
+		<p class="has-text-align-center has-cardo-font-family has-x-large-font-size" style="letter-spacing:-0.02em;line-height:1.2"><em><?php esc_html_e( '“Études has saved us thousands of hours of work and has unlocked insights we never thought possible.”', 'twentytwentyfour' ); ?></em></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->
@@ -322,16 +324,16 @@
 	<div class="wp-block-group">
 		<!-- wp:image {"id":86,"width":64,"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"border":{"radius":"100px"}},"className":"is-style-default"} -->
 		<figure class="wp-block-image size-full is-resized has-custom-border is-style-default">
-			<img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/tt4_testimonial_avatar.jpg" alt="" class="wp-image-86" style="border-radius:100px;aspect-ratio:1;object-fit:cover;width:64px" width="64"/>
+			<img src="<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/images/tt4_testimonial_avatar.jpg' ); ?>" alt="" class="wp-image-86" style="border-radius:100px;aspect-ratio:1;object-fit:cover;width:64px" width="64"/>
 		</figure>
 		<!-- /wp:image -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.9rem"}}} -->
-		<p style="font-size:0.9rem"><strong>Annie Steiner</strong></p>
+		<p style="font-size:0.9rem"><strong><?php esc_html_e( 'Annie Steiner', 'twentytwentyfour' ); ?></strong></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}},"typography":{"fontSize":"0.9rem"}},"textColor":"secondary"} -->
-		<p class="has-secondary-color has-text-color has-link-color" style="font-size:0.9rem">CEO, Greenprint</p>
+		<p class="has-secondary-color has-text-color has-link-color" style="font-size:0.9rem"><?php esc_html_e( 'CEO, Greenprint', 'twentytwentyfour' ); ?></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->
@@ -341,7 +343,7 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"8vh","bottom":"8vh"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-top:8vh;padding-bottom:8vh">
 	<!-- wp:heading {"align":"wide"} -->
-	<h2 class="wp-block-heading alignwide">Watch, Read, Listen</h2>
+	<h2 class="wp-block-heading alignwide"><?php esc_html_e( 'Watch, Read, Listen', 'twentytwentyfour' ); ?></h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|70"}}}} -->
@@ -431,18 +433,18 @@
 	<!-- wp:group {"align":"wide","style":{"border":{"radius":"16px"},"spacing":{"padding":{"top":"6vh","bottom":"6vh","left":"6vw","right":"6vw"}}},"backgroundColor":"tertiary","layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 	<div class="wp-block-group alignwide has-tertiary-background-color has-background" style="border-radius:16px;padding-top:6vh;padding-right:6vw;padding-bottom:6vh;padding-left:6vw">
 		<!-- wp:heading {"textAlign":"center"} -->
-		<h2 class="wp-block-heading has-text-align-center">Join 900+ subscribers</h2>
+		<h2 class="wp-block-heading has-text-align-center"><?php esc_html_e( 'Join 900+ subscribers', 'twentytwentyfour' ); ?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center">Stay in the loop with everything you need to know.</p>
+		<p class="has-text-align-center"><?php esc_html_e( 'Stay in the loop with everything you need to know.', 'twentytwentyfour' ); ?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 		<div class="wp-block-buttons">
 			<!-- wp:button -->
 			<div class="wp-block-button">
-				<a class="wp-block-button__link wp-element-button">Sign Up</a>
+				<a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Sign Up', 'twentytwentyfour' ); ?></a>
 			</div>
 			<!-- /wp:button -->
 		</div>

--- a/patterns/home.php
+++ b/patterns/home.php
@@ -7,339 +7,447 @@
  */
 ?>
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"6vh","bottom":"6vh"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:6vh;padding-bottom:6vh"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|80"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
-<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:heading {"textAlign":"center"} -->
-<h2 class="wp-block-heading has-text-align-center">A commitment to innovation and sustainability</h2>
-<!-- /wp:heading -->
+<div class="wp-block-group" style="padding-top:6vh;padding-bottom:6vh">
+	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|80"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
+	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--80)">
+		<!-- wp:heading {"textAlign":"center"} -->
+		<h2 class="wp-block-heading has-text-align-center">A commitment to innovation and sustainability</h2>
+		<!-- /wp:heading -->
 
-<!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}}},"fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0">Études is a pioneering firm that seamlessly merges creativity and functionality to redefine architectural excellence.</p>
-<!-- /wp:paragraph -->
+		<!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}}},"fontSize":"small"} -->
+		<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0">Études is a pioneering firm that seamlessly merges creativity and functionality to redefine architectural excellence.</p>
+		<!-- /wp:paragraph -->
 
-<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-<div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Learn More</a></div>
-<!-- /wp:button --></div>
-<!-- /wp:buttons --></div>
-<!-- /wp:group -->
+		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+		<div class="wp-block-buttons">
+			<!-- wp:button -->
+			<div class="wp-block-button">
+				<a class="wp-block-button__link wp-element-button">Learn More</a>
+			</div>
+			<!-- /wp:button -->
+		</div>
+		<!-- /wp:buttons -->
+	</div>
+	<!-- /wp:group -->
 
-<!-- wp:image {"align":"wide","id":369,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image alignwide size-full"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/tt4_business_image_hero.jpg" alt="" class="wp-image-369"/></figure>
-<!-- /wp:image --></div>
+	<!-- wp:image {"align":"wide","id":369,"sizeSlug":"full","linkDestination":"none"} -->
+	<figure class="wp-block-image alignwide size-full"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/tt4_business_image_hero.jpg" alt="" class="wp-image-369"/></figure>
+	<!-- /wp:image -->
+</div>
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"6vh","bottom":"10vh"}},"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"backgroundColor":"tertiary","textColor":"contrast","layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-contrast-color has-tertiary-background-color has-text-color has-background has-link-color" style="padding-top:6vh;padding-bottom:10vh"><!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0">✳︎</p>
-<!-- /wp:paragraph -->
+<div class="wp-block-group has-contrast-color has-tertiary-background-color has-text-color has-background has-link-color" style="padding-top:6vh;padding-bottom:10vh">
+	<!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
+	<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0">✳︎</p>
+	<!-- /wp:paragraph -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
-<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast"} -->
-<h2 class="wp-block-heading has-text-align-center has-contrast-color has-text-color has-link-color">A passion for creating spaces</h2>
-<!-- /wp:heading -->
+	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
+	<div class="wp-block-group">
+		<!-- wp:heading {"textAlign":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast"} -->
+		<h2 class="wp-block-heading has-text-align-center has-contrast-color has-text-color has-link-color">A passion for creating spaces</h2>
+		<!-- /wp:heading -->
 
-<!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}}},"fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0">Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->
+		<!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}}},"fontSize":"small"} -->
+		<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0">Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
 
-<!-- wp:spacer {"height":"30px"} -->
-<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+	<!-- wp:spacer {"height":"30px"} -->
+	<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
 
-<!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}}}} -->
-<div class="wp-block-columns alignwide" style="padding-top:0px;padding-bottom:0px"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
-<!-- /wp:paragraph -->
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}}}} -->
+	<div class="wp-block-columns alignwide" style="padding-top:0px;padding-bottom:0px">
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
+			<div class="wp-block-group">
+				<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
+				<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size"><strong>Consulting</strong></p>
-<!-- /wp:paragraph -->
+				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+				<p class="has-text-align-center has-small-font-size"><strong>Consulting</strong></p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"align":"left"} -->
-<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:column -->
+				<!-- wp:paragraph {"align":"left"} -->
+				<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:column -->
 
-<!-- wp:column -->
-<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
-<!-- /wp:paragraph -->
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
+			<div class="wp-block-group">
+				<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
+				<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size"><strong>Project Management</strong></p>
-<!-- /wp:paragraph -->
+				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+				<p class="has-text-align-center has-small-font-size"><strong>Project Management</strong></p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"align":"left"} -->
-<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:column -->
+				<!-- wp:paragraph {"align":"left"} -->
+				<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:column -->
 
-<!-- wp:column -->
-<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
-<!-- /wp:paragraph -->
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
+			<div class="wp-block-group">
+				<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
+				<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size"><strong>Architectural Solutions</strong></p>
-<!-- /wp:paragraph -->
+				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+				<p class="has-text-align-center has-small-font-size"><strong>Architectural Solutions</strong></p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"align":"left"} -->
-<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->
+				<!-- wp:paragraph {"align":"left"} -->
+				<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
 
-<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0"},"padding":{"top":"0px","bottom":"0px"}}}} -->
-<div class="wp-block-columns alignwide" style="padding-top:0px;padding-bottom:0px"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
-<!-- /wp:paragraph -->
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0"},"padding":{"top":"0px","bottom":"0px"}}}} -->
+	<div class="wp-block-columns alignwide" style="padding-top:0px;padding-bottom:0px">
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
+			<div class="wp-block-group">
+				<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
+				<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size"><strong>Renovation and restoration</strong></p>
-<!-- /wp:paragraph -->
+				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+				<p class="has-text-align-center has-small-font-size"><strong>Renovation and restoration</strong></p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"align":"left"} -->
-<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:column -->
+				<!-- wp:paragraph {"align":"left"} -->
+				<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:column -->
 
-<!-- wp:column -->
-<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
-<!-- /wp:paragraph -->
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
+			<div class="wp-block-group">
+				<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
+				<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size"><strong>Continuous Support</strong></p>
-<!-- /wp:paragraph -->
+				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+				<p class="has-text-align-center has-small-font-size"><strong>Continuous Support</strong></p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"align":"left"} -->
-<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:column -->
+				<!-- wp:paragraph {"align":"left"} -->
+				<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:column -->
 
-<!-- wp:column -->
-<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
-<!-- /wp:paragraph -->
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
+			<div class="wp-block-group">
+				<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
+				<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size"><strong>App Access</strong></p>
-<!-- /wp:paragraph -->
+				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+				<p class="has-text-align-center has-small-font-size"><strong>App Access</strong></p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"align":"left"} -->
-<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
+				<!-- wp:paragraph {"align":"left"} -->
+				<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+</div>
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"6vh","bottom":"8vh"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:6vh;padding-bottom:8vh"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0">✳︎</p>
-<!-- /wp:paragraph -->
+<div class="wp-block-group" style="padding-top:6vh;padding-bottom:8vh">
+	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
+		<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0">✳︎</p>
+		<!-- /wp:paragraph -->
 
-<!-- wp:heading {"textAlign":"center"} -->
-<h2 class="wp-block-heading has-text-align-center">An array of resources</h2>
-<!-- /wp:heading -->
+		<!-- wp:heading {"textAlign":"center"} -->
+		<h2 class="wp-block-heading has-text-align-center">An array of resources</h2>
+		<!-- /wp:heading -->
 
-<!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}}},"fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0">Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->
+		<!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}}},"fontSize":"small"} -->
+		<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0">Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
 
-<!-- wp:spacer {"height":"4vh"} -->
-<div style="height:4vh" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+	<!-- wp:spacer {"height":"4vh"} -->
+	<div style="height:4vh" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
 
-<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|80"}}}} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center"} -->
-<div class="wp-block-column is-vertically-aligned-center"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"left","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-left has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0">✳︎</p>
-<!-- /wp:paragraph -->
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|80"}}}} -->
+	<div class="wp-block-columns alignwide">
+		<!-- wp:column {"verticalAlignment":"center"} -->
+		<div class="wp-block-column is-vertically-aligned-center">
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+			<div class="wp-block-group">
+				<!-- wp:paragraph {"align":"left","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
+				<p class="has-text-align-left has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0">✳︎</p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:heading {"level":3,"fontSize":"large"} -->
-<h3 class="wp-block-heading has-large-font-size">Études Architect App</h3>
-<!-- /wp:heading --></div>
-<!-- /wp:group -->
+				<!-- wp:heading {"level":3,"fontSize":"large"} -->
+				<h3 class="wp-block-heading has-large-font-size">Études Architect App</h3>
+				<!-- /wp:heading -->
+			</div>
+			<!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:paragraph -->
-<p><strong>✓</strong> Collaborate with fellow architects</p>
-<!-- /wp:paragraph -->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+			<div class="wp-block-group">
+				<!-- wp:paragraph -->
+				<p><strong>✓</strong> Collaborate with fellow architects</p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph -->
-<p><strong>✓</strong> Showcase your projects</p>
-<!-- /wp:paragraph -->
+				<!-- wp:paragraph -->
+				<p><strong>✓</strong> Showcase your projects</p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph -->
-<p><strong>✓</strong> Experience the world of architecture like never before</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:column -->
+				<!-- wp:paragraph -->
+				<p><strong>✓</strong> Experience the world of architecture like never before</p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:column -->
 
-<!-- wp:column -->
-<div class="wp-block-column"><!-- wp:image {"id":370,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/tt4_business_image_app.jpg" alt="" class="wp-image-370"/></figure>
-<!-- /wp:image --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:image {"id":370,"sizeSlug":"large","linkDestination":"none"} -->
+			<figure class="wp-block-image size-large">
+				<img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/tt4_business_image_app.jpg" alt="" class="wp-image-370"/>
+			</figure>
+			<!-- /wp:image -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
 
-<!-- wp:spacer {"height":"4vh"} -->
-<div style="height:4vh" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+	<!-- wp:spacer {"height":"4vh"} -->
+	<div style="height:4vh" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
 
-<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|80"}}}} -->
-<div class="wp-block-columns alignwide"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:image {"id":67,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/tt4_home_image-2.jpg" alt="" class="wp-image-67"/></figure>
-<!-- /wp:image --></div>
-<!-- /wp:column -->
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|80"}}}} -->
+	<div class="wp-block-columns alignwide">
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:image {"id":67,"sizeSlug":"large","linkDestination":"none"} -->
+			<figure class="wp-block-image size-large">
+				<img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/tt4_home_image-2.jpg" alt="" class="wp-image-67"/>
+			</figure>
+			<!-- /wp:image -->
+		</div>
+		<!-- /wp:column -->
 
-<!-- wp:column {"verticalAlignment":"center"} -->
-<div class="wp-block-column is-vertically-aligned-center"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"left","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-left has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0">✳︎</p>
-<!-- /wp:paragraph -->
+		<!-- wp:column {"verticalAlignment":"center"} -->
+		<div class="wp-block-column is-vertically-aligned-center">
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+			<div class="wp-block-group">
+				<!-- wp:paragraph {"align":"left","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
+				<p class="has-text-align-left has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0">✳︎</p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:heading {"level":3,"fontSize":"large"} -->
-<h3 class="wp-block-heading has-large-font-size">Études Newsletter</h3>
-<!-- /wp:heading --></div>
-<!-- /wp:group -->
+				<!-- wp:heading {"level":3,"fontSize":"large"} -->
+				<h3 class="wp-block-heading has-large-font-size">Études Newsletter</h3>
+				<!-- /wp:heading -->
+			</div>
+			<!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:paragraph -->
-<p><strong>✓</strong> Dive into a world of thought-provoking articles</p>
-<!-- /wp:paragraph -->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+			<div class="wp-block-group">
+				<!-- wp:paragraph -->
+				<p><strong>✓</strong> Dive into a world of thought-provoking articles</p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph -->
-<p><strong>✓</strong> Read case studies that celebrate the artistry of architecture</p>
-<!-- /wp:paragraph -->
+				<!-- wp:paragraph -->
+				<p><strong>✓</strong> Read case studies that celebrate the artistry of architecture</p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:paragraph -->
-<p><strong>✓</strong> Gain exclusive access to design insights</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
+				<!-- wp:paragraph -->
+				<p><strong>✓</strong> Gain exclusive access to design insights</p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+</div>
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"12vh","bottom":"12vh","left":"6vw","right":"6vw"}},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"backgroundColor":"contrast","textColor":"base","layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-base-color has-contrast-background-color has-text-color has-background has-link-color" style="padding-top:12vh;padding-right:6vw;padding-bottom:12vh;padding-left:6vw"><!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
-<div class="wp-block-group alignwide"><!-- wp:paragraph {"align":"center","style":{"typography":{"lineHeight":"1.2","letterSpacing":"-0.02em"}},"fontSize":"x-large","fontFamily":"cardo"} -->
-<p class="has-text-align-center has-cardo-font-family has-x-large-font-size" style="letter-spacing:-0.02em;line-height:1.2"><em>“Études has saved us thousands of hours of work and has unlocked insights we never thought possible.”</em></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->
+<div class="wp-block-group has-base-color has-contrast-background-color has-text-color has-background has-link-color" style="padding-top:12vh;padding-right:6vw;padding-bottom:12vh;padding-left:6vw">
+	<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
+	<div class="wp-block-group alignwide">
+		<!-- wp:paragraph {"align":"center","style":{"typography":{"lineHeight":"1.2","letterSpacing":"-0.02em"}},"fontSize":"x-large","fontFamily":"cardo"} -->
+		<p class="has-text-align-center has-cardo-font-family has-x-large-font-size" style="letter-spacing:-0.02em;line-height:1.2"><em>“Études has saved us thousands of hours of work and has unlocked insights we never thought possible.”</em></p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"0.2rem"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
-<div class="wp-block-group"><!-- wp:image {"id":86,"width":64,"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"border":{"radius":"100px"}},"className":"is-style-default"} -->
-<figure class="wp-block-image size-full is-resized has-custom-border is-style-default"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/tt4_testimonial_avatar.jpg" alt="" class="wp-image-86" style="border-radius:100px;aspect-ratio:1;object-fit:cover;width:64px" width="64"/></figure>
-<!-- /wp:image -->
+	<!-- wp:group {"style":{"spacing":{"blockGap":"0.2rem"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
+	<div class="wp-block-group">
+		<!-- wp:image {"id":86,"width":64,"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"border":{"radius":"100px"}},"className":"is-style-default"} -->
+		<figure class="wp-block-image size-full is-resized has-custom-border is-style-default">
+			<img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/tt4_testimonial_avatar.jpg" alt="" class="wp-image-86" style="border-radius:100px;aspect-ratio:1;object-fit:cover;width:64px" width="64"/>
+		</figure>
+		<!-- /wp:image -->
 
-<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.9rem"}}} -->
-<p style="font-size:0.9rem"><strong>Annie Steiner</strong></p>
-<!-- /wp:paragraph -->
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.9rem"}}} -->
+		<p style="font-size:0.9rem"><strong>Annie Steiner</strong></p>
+		<!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}},"typography":{"fontSize":"0.9rem"}},"textColor":"secondary"} -->
-<p class="has-secondary-color has-text-color has-link-color" style="font-size:0.9rem">CEO, Greenprint</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"8vh","bottom":"8vh"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:8vh;padding-bottom:8vh"><!-- wp:heading {"align":"wide"} -->
-<h2 class="wp-block-heading alignwide">Watch, Read, Listen</h2>
-<!-- /wp:heading -->
-
-<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|70"}}}} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"width":"60%"} -->
-<div class="wp-block-column" style="flex-basis:60%"><!-- wp:query {"queryId":1,"query":{"perPage":"1","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
-<div class="wp-block-query"><!-- wp:post-template -->
-<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|50"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:post-featured-image {"aspectRatio":"auto","height":"","scale":"contain","style":{"layout":{"selfStretch":"fit","flexSize":null}}} /-->
-
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
-
-<!-- wp:group {"style":{"spacing":{"blockGap":"0.3em","padding":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
-<div class="wp-block-group" style="padding-top:0;padding-bottom:0"><!-- wp:post-date {"format":"M j, Y"} /-->
-
-<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} -->
-<p class="has-secondary-color has-text-color has-link-color">—</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:post-author-name /-->
-
-<!-- wp:post-terms {"term":"category","prefix":"in ","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"secondary"} /--></div>
-<!-- /wp:group -->
-
-<!-- wp:post-excerpt {"moreText":"","fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-<!-- /wp:post-template --></div>
-<!-- /wp:query --></div>
-<!-- /wp:column -->
-
-<!-- wp:column {"width":"40%"} -->
-<div class="wp-block-column" style="flex-basis:40%"><!-- wp:query {"queryId":1,"query":{"perPage":"2","pages":0,"offset":1,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
-<div class="wp-block-query"><!-- wp:post-template -->
-<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|50"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:post-featured-image {"height":""} /-->
-
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"style":{"typography":{"fontSize":"1.7rem"}}} /-->
-
-<!-- wp:group {"style":{"spacing":{"blockGap":"0.3em","padding":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
-<div class="wp-block-group" style="padding-top:0;padding-bottom:0"><!-- wp:post-date {"format":"M j, Y"} /-->
-
-<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} -->
-<p class="has-secondary-color has-text-color has-link-color">—</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:post-author-name /-->
-
-<!-- wp:post-terms {"term":"category","prefix":"in ","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"secondary"} /--></div>
-<!-- /wp:group -->
-
-<!-- wp:post-excerpt {"moreText":"","style":{"typography":{"fontSize":"0.9rem"}}} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-<!-- /wp:post-template --></div>
-<!-- /wp:query --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
+		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}},"typography":{"fontSize":"0.9rem"}},"textColor":"secondary"} -->
+		<p class="has-secondary-color has-text-color has-link-color" style="font-size:0.9rem">CEO, Greenprint</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+</div>
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"8vh","bottom":"8vh"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:8vh;padding-bottom:8vh"><!-- wp:group {"align":"wide","style":{"border":{"radius":"16px"},"spacing":{"padding":{"top":"6vh","bottom":"6vh","left":"6vw","right":"6vw"}}},"backgroundColor":"tertiary","layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-<div class="wp-block-group alignwide has-tertiary-background-color has-background" style="border-radius:16px;padding-top:6vh;padding-right:6vw;padding-bottom:6vh;padding-left:6vw"><!-- wp:heading {"textAlign":"center"} -->
-<h2 class="wp-block-heading has-text-align-center">Join 900+ subscribers</h2>
-<!-- /wp:heading -->
+<div class="wp-block-group" style="padding-top:8vh;padding-bottom:8vh">
+	<!-- wp:heading {"align":"wide"} -->
+	<h2 class="wp-block-heading alignwide">Watch, Read, Listen</h2>
+	<!-- /wp:heading -->
 
-<!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center">Stay in the loop with everything you need to know.</p>
-<!-- /wp:paragraph -->
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|70"}}}} -->
+	<div class="wp-block-columns alignwide">
+		<!-- wp:column {"width":"60%"} -->
+		<div class="wp-block-column" style="flex-basis:60%">
+			<!-- wp:query {"queryId":1,"query":{"perPage":"1","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+			<div class="wp-block-query">
+				<!-- wp:post-template -->
+				<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|50"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+				<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--50)">
+					<!-- wp:post-featured-image {"aspectRatio":"auto","height":"","scale":"contain","style":{"layout":{"selfStretch":"fit","flexSize":null}}} /-->
 
-<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-<div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Sign Up</a></div>
-<!-- /wp:button --></div>
-<!-- /wp:buttons --></div>
-<!-- /wp:group --></div>
+					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+					<div class="wp-block-group">
+						<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+
+						<!-- wp:group {"style":{"spacing":{"blockGap":"0.3em","padding":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
+						<div class="wp-block-group" style="padding-top:0;padding-bottom:0">
+							<!-- wp:post-date {"format":"M j, Y"} /-->
+
+							<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} -->
+							<p class="has-secondary-color has-text-color has-link-color">—</p>
+							<!-- /wp:paragraph -->
+
+							<!-- wp:post-author-name /-->
+
+							<!-- wp:post-terms {"term":"category","prefix":"in ","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"secondary"} /-->
+						</div>
+						<!-- /wp:group -->
+
+						<!-- wp:post-excerpt {"moreText":"","fontSize":"small"} /-->
+					</div>
+					<!-- /wp:group -->
+				</div>
+				<!-- /wp:group -->
+				<!-- /wp:post-template -->
+			</div>
+			<!-- /wp:query -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"width":"40%"} -->
+		<div class="wp-block-column" style="flex-basis:40%">
+			<!-- wp:query {"queryId":1,"query":{"perPage":"2","pages":0,"offset":1,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+			<div class="wp-block-query">
+				<!-- wp:post-template -->
+				<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|50"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+				<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--50)">
+					<!-- wp:post-featured-image {"height":""} /-->
+
+					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+					<div class="wp-block-group">
+						<!-- wp:post-title {"isLink":true,"style":{"typography":{"fontSize":"1.7rem"}}} /-->
+
+						<!-- wp:group {"style":{"spacing":{"blockGap":"0.3em","padding":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
+						<div class="wp-block-group" style="padding-top:0;padding-bottom:0">
+							<!-- wp:post-date {"format":"M j, Y"} /-->
+
+							<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} -->
+							<p class="has-secondary-color has-text-color has-link-color">—</p>
+							<!-- /wp:paragraph -->
+
+							<!-- wp:post-author-name /-->
+
+							<!-- wp:post-terms {"term":"category","prefix":"in ","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"secondary"} /-->
+						</div>
+						<!-- /wp:group -->
+
+						<!-- wp:post-excerpt {"moreText":"","style":{"typography":{"fontSize":"0.9rem"}}} /-->
+					</div>
+					<!-- /wp:group -->
+				</div>
+				<!-- /wp:group -->
+				<!-- /wp:post-template -->
+			</div>
+			<!-- /wp:query -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"8vh","bottom":"8vh"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-top:8vh;padding-bottom:8vh">
+	<!-- wp:group {"align":"wide","style":{"border":{"radius":"16px"},"spacing":{"padding":{"top":"6vh","bottom":"6vh","left":"6vw","right":"6vw"}}},"backgroundColor":"tertiary","layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+	<div class="wp-block-group alignwide has-tertiary-background-color has-background" style="border-radius:16px;padding-top:6vh;padding-right:6vw;padding-bottom:6vh;padding-left:6vw">
+		<!-- wp:heading {"textAlign":"center"} -->
+		<h2 class="wp-block-heading has-text-align-center">Join 900+ subscribers</h2>
+		<!-- /wp:heading -->
+
+		<!-- wp:paragraph {"align":"center"} -->
+		<p class="has-text-align-center">Stay in the loop with everything you need to know.</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+		<div class="wp-block-buttons">
+			<!-- wp:button -->
+			<div class="wp-block-button">
+				<a class="wp-block-button__link wp-element-button">Sign Up</a>
+			</div>
+			<!-- /wp:button -->
+		</div>
+		<!-- /wp:buttons -->
+	</div>
+	<!-- /wp:group -->
+</div>
 <!-- /wp:group -->


### PR DESCRIPTION
This addresses the issue https://github.com/WordPress/twentytwentyfour/issues/62 and adds translation functions to static text in the Home pattern. It also sanitizes some URLs too.

I also added code formatting like spacing and indentation to format code nicely.