### PR TITLE
Fix missing translations

### DIFF
--- a/patterns/about.php
+++ b/patterns/about.php
@@ -10,11 +10,12 @@
 <!-- wp:paragraph {"align":"center","style":{"typography":{"fontStyle":"italic","fontWeight":"400","lineHeight":"1.3"},"spacing":{"padding":{"top":"6.25rem","bottom":"6.25rem"}}},"backgroundColor":"base","fontSize":"large","fontFamily":"cardo"} -->
 <p class="has-text-align-center has-base-background-color has-background has-cardo-font-family has-large-font-size" style="padding-top:6.25rem;padding-bottom:6.25rem;font-style:italic;font-weight:400;line-height:1.3">
 	<?php
-		/* Translators: WordPress link. */
-		$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfour' ) ) . '" rel="nofollow">' . esc_html__( 'Money Studies', 'twentytwentyfour' ) . '</a>';
+		/* Translators: About link placeholder */
+		$about_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfour' ) ) . '" rel="nofollow">' . esc_html__( 'Money Studies', 'twentytwentyfour' ) . '</a>';
 		echo sprintf(
+			/* Translators: About text placeholder */
 			esc_html__( 'I write about finance, management and economy, my book “%1$s” is out now.', 'twentytwentyfour' ),
-			$wordpress_link
+			$about_link
 		);
 		?>
 </p>

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -21,6 +21,7 @@
 				/* Translators: WordPress link. */
 				$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfour' ) ) . '" rel="nofollow">WordPress</a>';
 				echo sprintf(
+					/* Translators: Designed with WordPress */
 					esc_html__( 'Designed with %1$s', 'twentytwentyfour' ),
 					$wordpress_link
 				);


### PR DESCRIPTION
Adds missing `Translator` strings, and corrects the description of the translated text in the about pattern. This gets rid of a couple of existing lint warnings.