### PR TITLE
Add "posts" pattern

### DIFF
--- a/patterns/posts.php
+++ b/patterns/posts.php
@@ -8,7 +8,7 @@
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}}} -->
-<h2 class="wp-block-heading alignwide" style="margin-bottom:var(--wp--preset--spacing--60)">Watch, Read, Listen</h2>
+<h2 class="wp-block-heading alignwide" style="margin-bottom:var(--wp--preset--spacing--60)"><?php echo esc_html_x( 'Watch, Read, Listen', 'Heading before a list of posts', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|60"}}}} -->
@@ -25,7 +25,7 @@
 <div class="wp-block-group"><!-- wp:post-date /-->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"}},"textColor":"contrast-2"} -->
-<p class="has-contrast-2-color has-text-color" style="font-size:0.8rem">—</p>
+<p class="has-contrast-2-color has-text-color" style="font-size:0.8rem"><?php echo esc_html_x( '—', 'Separator between post date and author name', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:post-author-name {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} /-->
@@ -49,7 +49,7 @@
 <div class="wp-block-group"><!-- wp:post-date /-->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"}},"textColor":"contrast-2"} -->
-<p class="has-contrast-2-color has-text-color" style="font-size:0.8rem">—</p>
+<p class="has-contrast-2-color has-text-color" style="font-size:0.8rem"><?php echo esc_html_x( '—', 'Separator between post date and author name', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:post-author-name {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} /-->

--- a/patterns/posts.php
+++ b/patterns/posts.php
@@ -1,28 +1,19 @@
-<?php
-/**
- * Title: Posts
- * Slug: twentytwentyfour/posts
- * Categories: posts
- */
-
-?>
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:heading {"align":"wide"} -->
-<h2 class="wp-block-heading alignwide"><?php echo esc_html__( 'Watch, Read, Listen', 'twentytwentyfour' ); ?></h2>
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}}} -->
+<h2 class="wp-block-heading alignwide" style="margin-bottom:var(--wp--preset--spacing--60)">Watch, Read, Listen</h2>
 <!-- /wp:heading -->
 
 <!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|60"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"60%"} -->
 <div class="wp-block-column" style="flex-basis:60%"><!-- wp:query {"queryId":16,"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
-<!-- wp:post-featured-image /-->
+<!-- wp:post-featured-image {"style":{"spacing":{"padding":{"bottom":"0"}}}} /-->
 
-<!-- wp:post-title {"style":{"typography":{"fontSize":"1.25rem"}}} /-->
+<!-- wp:post-title {"level":3,"style":{"typography":{"fontSize":"1.25rem"},"spacing":{"margin":{"top":"var:preset|spacing|60"}}}} /-->
 
 <!-- wp:post-excerpt {"fontSize":"small"} /-->
 
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:post-date /-->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"}},"textColor":"secondary"} -->
@@ -42,7 +33,7 @@
 <div class="wp-block-query"><!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|60"}}} -->
 <!-- wp:post-featured-image /-->
 
-<!-- wp:post-title {"style":{"typography":{"fontSize":"1.25rem","lineHeight":"1.3"}}} /-->
+<!-- wp:post-title {"level":3,"style":{"typography":{"fontSize":"1.25rem","lineHeight":"1.3"}}} /-->
 
 <!-- wp:post-excerpt {"fontSize":"small"} /-->
 

--- a/patterns/posts.php
+++ b/patterns/posts.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Title: Posts
+ * Slug: twentytwentyfour/posts
+ * Categories: query
+ * Block Types: core/query
+ */
+?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}}} -->
 <h2 class="wp-block-heading alignwide" style="margin-bottom:var(--wp--preset--spacing--60)">Watch, Read, Listen</h2>
@@ -7,7 +15,7 @@
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"60%"} -->
 <div class="wp-block-column" style="flex-basis:60%"><!-- wp:query {"queryId":16,"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
-<!-- wp:post-featured-image {"style":{"spacing":{"padding":{"bottom":"0"}}}} /-->
+<!-- wp:post-featured-image {"aspectRatio":"123/100","style":{"spacing":{"padding":{"bottom":"0"}}}} /-->
 
 <!-- wp:post-title {"level":3,"style":{"typography":{"fontSize":"1.25rem"},"spacing":{"margin":{"top":"var:preset|spacing|60"}}}} /-->
 

--- a/patterns/posts.php
+++ b/patterns/posts.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Title: Posts
+ * Slug: twentytwentyfour/posts
+ * Categories: posts
+ */
+
+?>
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:heading {"align":"wide"} -->
+<h2 class="wp-block-heading alignwide"><?php echo esc_html__( 'Watch, Read, Listen', 'twentytwentyfour' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|60"}}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"width":"60%"} -->
+<div class="wp-block-column" style="flex-basis:60%"><!-- wp:query {"queryId":16,"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:post-featured-image /-->
+
+<!-- wp:post-title {"style":{"typography":{"fontSize":"1.25rem"}}} /-->
+
+<!-- wp:post-excerpt {"fontSize":"small"} /-->
+
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:post-date /-->
+
+<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"}},"textColor":"secondary"} -->
+<p class="has-secondary-color has-text-color" style="font-size:0.8rem">—</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:post-author-name {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} /-->
+
+<!-- wp:post-terms {"term":"category","prefix":"in ","style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} /--></div>
+<!-- /wp:group -->
+<!-- /wp:post-template --></div>
+<!-- /wp:query --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"40%","style":{"spacing":{"blockGap":"0"}}} -->
+<div class="wp-block-column" style="flex-basis:40%"><!-- wp:query {"queryId":16,"query":{"perPage":2,"pages":0,"offset":1,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+<div class="wp-block-query"><!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|60"}}} -->
+<!-- wp:post-featured-image /-->
+
+<!-- wp:post-title {"style":{"typography":{"fontSize":"1.25rem","lineHeight":"1.3"}}} /-->
+
+<!-- wp:post-excerpt {"fontSize":"small"} /-->
+
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:post-date /-->
+
+<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"}},"textColor":"secondary"} -->
+<p class="has-secondary-color has-text-color" style="font-size:0.8rem">—</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:post-author-name {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} /-->
+
+<!-- wp:post-terms {"term":"category","prefix":"in ","style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} /--></div>
+<!-- /wp:group -->
+<!-- /wp:post-template --></div>
+<!-- /wp:query --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->

--- a/patterns/posts.php
+++ b/patterns/posts.php
@@ -24,13 +24,13 @@
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:post-date /-->
 
-<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"}},"textColor":"secondary"} -->
-<p class="has-secondary-color has-text-color" style="font-size:0.8rem">—</p>
+<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"}},"textColor":"contrast-2"} -->
+<p class="has-contrast-2-color has-text-color" style="font-size:0.8rem">—</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:post-author-name {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} /-->
+<!-- wp:post-author-name {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} /-->
 
-<!-- wp:post-terms {"term":"category","prefix":"in ","style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} /--></div>
+<!-- wp:post-terms {"term":"category","prefix":"in ","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} /--></div>
 <!-- /wp:group -->
 <!-- /wp:post-template --></div>
 <!-- /wp:query --></div>
@@ -48,13 +48,13 @@
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:post-date /-->
 
-<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"}},"textColor":"secondary"} -->
-<p class="has-secondary-color has-text-color" style="font-size:0.8rem">—</p>
+<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"}},"textColor":"contrast-2"} -->
+<p class="has-contrast-2-color has-text-color" style="font-size:0.8rem">—</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:post-author-name {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} /-->
+<!-- wp:post-author-name {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} /-->
 
-<!-- wp:post-terms {"term":"category","prefix":"in ","style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} /--></div>
+<!-- wp:post-terms {"term":"category","prefix":"in ","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} /--></div>
 <!-- /wp:group -->
 <!-- /wp:post-template --></div>
 <!-- /wp:query --></div>

--- a/patterns/posts.php
+++ b/patterns/posts.php
@@ -7,11 +7,11 @@
  */
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}}} -->
-<h2 class="wp-block-heading alignwide" style="margin-bottom:var(--wp--preset--spacing--60)"><?php echo esc_html_x( 'Watch, Read, Listen', 'Heading before a list of posts', 'twentytwentyfour' ); ?></h2>
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} -->
+<h2 class="wp-block-heading alignwide" style="margin-bottom:var(--wp--preset--spacing--20)"><?php echo esc_html_x( 'Watch, Read, Listen', 'Heading before a list of posts', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|60"}}}} -->
+<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|30"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"60%"} -->
 <div class="wp-block-column" style="flex-basis:60%"><!-- wp:query {"queryId":16,"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 <div class="wp-block-query"><!-- wp:post-template -->


### PR DESCRIPTION
Tried replicating this pattern as closely as possible:

![image](https://github.com/WordPress/twentytwentyfour/assets/2846578/11f12421-6573-42b5-8ca7-6c8b39716e17)
[Figma](https://www.figma.com/file/AlYr03vh4dVimwYwQkTdf6/Twenty-Twenty-Four?type=design&node-id=492-4728&mode=design&t=Sp21Ytn3WpNk8aWP-4)

Some issues I ran into:
- The spacing presets don't match the space in the mockup.
  - The preset I used for spacing between columns, block title, and post title is 36px, but the spacing in Figma is 32px
  - The preset I used for spacing between meta is off; there's not a great way to measure this since it's formatted as a single paragraph, but I'm using a row block to get all of the information in one line
- The font size presets didn't match the mockup (I used custom sizing for the heading since the presets were way off, and the "small" size for the excerpt because it was only 1px off)
- I couldn't easily add "by" before the author name without it being a separate block

These issues are related to #34 and #49