### PR TITLE
Add fluid spacing scale

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -115,13 +115,38 @@
 			"wideSize": "1280px"
 		},
 		"spacing": {
-			"spacingScale": {
-				"increment": 1.5,
-				"mediumStep": 1.5,
-				"operator": "*",
-				"steps": 7,
-				"unit": "rem"
-			},
+			"spacingSizes": [
+				{
+					"name": "1",
+					"size": "min(24px, 4vw)",
+					"slug": "10"
+				},
+				{
+					"name": "2",
+					"size": "min(36px, 6vw)",
+					"slug": "20"
+				},
+				{
+					"name": "3",
+					"size": "min(60px, 10vw)",
+					"slug": "30"
+				},
+				{
+					"name": "4",
+					"size": "min(96px, 16vw)",
+					"slug": "40"
+				},
+				{
+					"name": "5",
+					"size": "min(156px, 26vw)",
+					"slug": "50"
+				},
+				{
+					"name": "6",
+					"size": "min(252px, 42vw)",
+					"slug": "60"
+				}
+			],
 			"units": [
 				"%",
 				"px",

--- a/theme.json
+++ b/theme.json
@@ -118,32 +118,32 @@
 			"spacingSizes": [
 				{
 					"name": "1",
-					"size": "min(24px, 4vw)",
+					"size": "min(1rem, 2vw)",
 					"slug": "10"
 				},
 				{
 					"name": "2",
-					"size": "min(36px, 6vw)",
+					"size": "min(1.5rem, 3vw)",
 					"slug": "20"
 				},
 				{
 					"name": "3",
-					"size": "min(60px, 10vw)",
+					"size": "min(2.5rem, 5vw)",
 					"slug": "30"
 				},
 				{
 					"name": "4",
-					"size": "min(96px, 16vw)",
+					"size": "min(4rem, 8vw)",
 					"slug": "40"
 				},
 				{
 					"name": "5",
-					"size": "min(156px, 26vw)",
+					"size": "min(6.5rem, 13vw)",
 					"slug": "50"
 				},
 				{
 					"name": "6",
-					"size": "min(252px, 42vw)",
+					"size": "min(10.5rem, 24vw)",
 					"slug": "60"
 				}
 			],


### PR DESCRIPTION
**Description**

Add a consistent fluid spacing scale that we can start leveraging in patterns, instead of using arbitrary values. This proposal uses the Fibonacci sequence. 

We can continue to iterate and refine the values, but I think it'd be good to have a consistent set to start working from. 

**Testing Instructions**

<!-- Provide steps for testing -->
1. Activate the theme. 
2. Add spacer block. 
3. Adjust the height to see the spacing presets. 
4. View on mobile to see the fluidity. 

**Screenshots**
<!-- Add screenshots of the change, if applicable -->

Desktop: 
<img width="641" alt="CleanShot 2023-08-27 at 10 56 52" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/3f7af8ea-9236-4433-8331-ac1e0e553258">

Mobile: 
<img width="394" alt="CleanShot 2023-08-27 at 11 04 14" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/79cc0ee3-a614-4e91-92f8-4d26ce2b46ce">

Example of this fluid spacing expressed in a pattern, with `40` as the outer padding: 
<img width="1231" alt="CleanShot 2023-08-28 at 09 44 47" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/6fc0346a-0600-46ab-9690-73fd8f2ed814">
<img width="358" alt="CleanShot 2023-08-28 at 09 44 58" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/a261044b-0863-4457-9d1b-73db48b396bd">
