### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Report a bug with the Twenty Twenty Four theme
+labels: "[Type] Bug"
+
+---
+
+**Description**
+<!-- A clear and concise description of what the bug is. -->
+
+**Step-by-step reproduction instructions**
+<!-- Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Environment info**
+<!--
+Please share the browser(s) are you seeing the problem on.
+Please share the Device you are using and operating system (e.g. "Desktop with Windows 10", "iPhone with iOS 14", etc.).
+ - Device:
+ - OS:
+ - Browser:
+ - Version:
+-->
+
+**Additional context**
+<!--
+Add any other context about the problem here.
+-->

--- a/.github/ISSUE_TEMPLATE/Feature---enhancement.md
+++ b/.github/ISSUE_TEMPLATE/Feature---enhancement.md
@@ -1,0 +1,18 @@
+---
+name: Feature / Enhancement
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+<!--
+Please describe if this feature or enhancement is related to a current problem
+or pain point. For example, "I'm always frustrated when ..." or "It is currently
+difficult to ...".
+-->
+
+**Describe the solution you'd like**
+<!--
+Please outline the feature or enhancement that you want and how it addresses any
+problem identified above.
+-->

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+<!--
+Please describe if this feature or enhancement is related to a current problem
+or pain point. For example, "I'm always frustrated when ..." or "It is currently
+difficult to ...".
+-->
+
+**Describe the solution you'd like**
+<!--
+Please outline the feature or enhancement that you want and how it addresses any
+problem identified above.
+-->

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -1,0 +1,8 @@
+---
+name: Question
+about: Ask a question
+
+---
+
+**Description**
+<!-- Please write your question. -->


### PR DESCRIPTION
**Description**

Adding issue templates to improve the organization and details for incoming issues, helping contributors. Taking the TT2 issue templates as a reference (with some tiny mods) as Maggie suggested [here](https://github.com/WordPress/twentytwentyfour/pull/75#pullrequestreview-1597148653).
