### PR TITLE
Remove default color palette

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -2,6 +2,7 @@
 	"settings": {
 		"appearanceTools": true,
 		"color": {
+			"defaultPalette": false,
 			"palette": [
 				{
 					"color": "#f9f9f9",


### PR DESCRIPTION
### Description

Proposing that we remove the default color palette, in support of making the Twenty Twenty Four experience much more tailored. It's less distracting without them, and we don't use those values anyhow. 

We'll continue to refine the theme colors, but in the meantime the defaults seem out of place. 

### Screenshots

| Before  | After |
| ------------- | ------------- |
|<img width="262" alt="CleanShot 2023-08-28 at 09 50 13" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/35a2efbd-2339-48f0-b3a4-350e085a5055">|<img width="263" alt="CleanShot 2023-08-28 at 09 49 44" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/e7b8f769-b694-4bf0-a00c-67d9954f64e0">|


### Testing

<!-- Provide steps for testing -->
1. Activate the theme.
2. Add a page with a paragraph.
3. Select "Color" to see the default colors not displaying.
