### PR TITLE
Apply missing translation/escaping functions to all current patterns

### DIFF
--- a/patterns/columns.php
+++ b/patterns/columns.php
@@ -12,7 +12,7 @@
 <div class="wp-block-group alignfull has-base-background-color has-background" style="padding-top:7em;padding-right:7em;padding-bottom:7em;padding-left:7em"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"33%","style":{"spacing":{"blockGap":"","padding":{"right":"12%"}}}} -->
 <div class="wp-block-column" style="padding-right:12%;flex-basis:33%"><!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading">We recognize the crucial role architecture plays in shaping a sustainable future.</h3>
+<h3 class="wp-block-heading"><?php echo esc_html__( 'We recognize the crucial role architecture plays in shaping a sustainable future.', 'twentytwentyfour' ); ?></h3>
 <!-- /wp:heading --></div>
 <!-- /wp:column -->
 
@@ -20,21 +20,21 @@
 <div class="wp-block-column"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
 <div class="wp-block-group"><!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
-<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">Consulting</h4>
+<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1"><?php echo esc_html__( 'Consulting', 'twentytwentyfour' ); ?></h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.</p>
+<p><?php echo esc_html__( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
-<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">Project Management</h4>
+<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1"><?php echo esc_html__( 'Project Management', 'twentytwentyfour' ); ?></h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.</p>
+<p><?php echo esc_html__( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
@@ -42,21 +42,21 @@
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
-<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">Design</h4>
+<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1"><?php echo esc_html__( 'Design', 'twentytwentyfour' ); ?></h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.</p>
+<p><?php echo esc_html__( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:heading {"level":4,"style":{"typography":{"lineHeight":"1.1","fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium","fontFamily":"system-font"} -->
-<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1">Maintenance</h4>
+<h4 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:700;line-height:1.1"><?php echo esc_html__( 'Maintenance', 'twentytwentyfour' ); ?></h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.</p>
+<p><?php echo esc_html__( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>

--- a/patterns/home.php
+++ b/patterns/home.php
@@ -9,16 +9,16 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"6vh","bottom":"6vh"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-top:6vh;padding-bottom:6vh"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|80"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 <div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:heading {"textAlign":"center"} -->
-<h2 class="wp-block-heading has-text-align-center">A commitment to innovation and sustainability</h2>
+<h2 class="wp-block-heading has-text-align-center"><?php echo esc_html__( 'A commitment to innovation and sustainability', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}}},"fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0">Études is a pioneering firm that seamlessly merges creativity and functionality to redefine architectural excellence.</p>
+<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0"><?php echo esc_html__( 'Études is a pioneering firm that seamlessly merges creativity and functionality to redefine architectural excellence.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Learn More</a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo esc_html__( 'Learn More', 'twentytwentyfour' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group -->
@@ -30,16 +30,16 @@
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"6vh","bottom":"10vh"}},"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"backgroundColor":"tertiary","textColor":"contrast","layout":{"type":"constrained"}} -->
 <div class="wp-block-group has-contrast-color has-tertiary-background-color has-text-color has-background has-link-color" style="padding-top:6vh;padding-bottom:10vh"><!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0">✳︎</p>
+<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0"><?php echo esc_html__( '✳︎', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 <div class="wp-block-group"><!-- wp:heading {"textAlign":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast"} -->
-<h2 class="wp-block-heading has-text-align-center has-contrast-color has-text-color has-link-color">A passion for creating spaces</h2>
+<h2 class="wp-block-heading has-text-align-center has-contrast-color has-text-color has-link-color"><?php echo esc_html__( 'A passion for creating spaces', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}}},"fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0">Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.</p>
+<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0"><?php echo esc_html__( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
@@ -51,15 +51,15 @@
 <div class="wp-block-columns alignwide" style="padding-top:0px;padding-bottom:0px"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
+<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size"><?php echo esc_html__( '✳', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size"><strong>Consulting</strong></p>
+<p class="has-text-align-center has-small-font-size"><strong><?php echo esc_html__( 'Consulting', 'twentytwentyfour' ); ?></strong></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"left"} -->
-<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+<p class="has-text-align-left"><?php echo esc_html__( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->
@@ -67,15 +67,15 @@
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
+<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size"><?php echo esc_html__( '✳', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size"><strong>Project Management</strong></p>
+<p class="has-text-align-center has-small-font-size"><strong><?php echo esc_html__( 'Project Management', 'twentytwentyfour' ); ?></strong></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"left"} -->
-<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+<p class="has-text-align-left"><?php echo esc_html__( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->
@@ -83,15 +83,15 @@
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
+<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size"><?php echo esc_html__( '✳', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size"><strong>Architectural Solutions</strong></p>
+<p class="has-text-align-center has-small-font-size"><strong><?php echo esc_html__( 'Architectural Solutions', 'twentytwentyfour' ); ?></strong></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"left"} -->
-<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+<p class="has-text-align-left"><?php echo esc_html__( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
@@ -101,15 +101,15 @@
 <div class="wp-block-columns alignwide" style="padding-top:0px;padding-bottom:0px"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
+<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size"><?php echo esc_html__( '✳', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size"><strong>Renovation and restoration</strong></p>
+<p class="has-text-align-center has-small-font-size"><strong><?php echo esc_html__( 'Renovation and restoration', 'twentytwentyfour' ); ?></strong></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"left"} -->
-<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+<p class="has-text-align-left"><?php echo esc_html__( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->
@@ -117,15 +117,15 @@
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
+<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size"><?php echo esc_html__( '✳', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size"><strong>Continuous Support</strong></p>
+<p class="has-text-align-center has-small-font-size"><strong><?php echo esc_html__( 'Continuous Support', 'twentytwentyfour' ); ?></strong></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"left"} -->
-<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+<p class="has-text-align-left"><?php echo esc_html__( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->
@@ -133,15 +133,15 @@
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size">✳</p>
+<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size"><?php echo esc_html__( '✳', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size"><strong>App Access</strong></p>
+<p class="has-text-align-center has-small-font-size"><strong><?php echo esc_html__( 'App Access', 'twentytwentyfour' ); ?></strong></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"left"} -->
-<p class="has-text-align-left">Experience the fusion of imagination and expertise with Études Architectural Solutions.</p>
+<p class="has-text-align-left"><?php echo esc_html__( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
@@ -151,15 +151,15 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"6vh","bottom":"8vh"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-top:6vh;padding-bottom:8vh"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0">✳︎</p>
+<p class="has-text-align-center has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0"><?php echo esc_html__( '✳︎', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"textAlign":"center"} -->
-<h2 class="wp-block-heading has-text-align-center">An array of resources</h2>
+<h2 class="wp-block-heading has-text-align-center"><?php echo esc_html__( 'An array of resources', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}}},"fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0">Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.</p>
+<p class="has-text-align-center has-small-font-size" style="padding-right:0;padding-left:0"><?php echo esc_html__( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
@@ -171,25 +171,25 @@
 <div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center"} -->
 <div class="wp-block-column is-vertically-aligned-center"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"align":"left","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-left has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0">✳︎</p>
+<p class="has-text-align-left has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0"><?php echo esc_html__( '✳︎', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3,"fontSize":"large"} -->
-<h3 class="wp-block-heading has-large-font-size">Études Architect App</h3>
+<h3 class="wp-block-heading has-large-font-size"><?php echo esc_html__( 'Études Architect App', 'twentytwentyfour' ); ?></h3>
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:paragraph -->
-<p><strong>✓</strong> Collaborate with fellow architects</p>
+<p><strong><?php echo esc_html__( '✓', 'twentytwentyfour' ); ?></strong>&nbsp;<?php echo esc_html__( 'Collaborate with fellow architects', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><strong>✓</strong> Showcase your projects</p>
+<p><strong><?php echo esc_html__( '✓', 'twentytwentyfour' ); ?></strong>&nbsp;<?php echo esc_html__( 'Showcase your projects', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><strong>✓</strong> Experience the world of architecture like never before</p>
+<p><strong><?php echo esc_html__( '✓', 'twentytwentyfour' ); ?></strong>&nbsp;<?php echo esc_html__( 'Experience the world of architecture like never before', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->
@@ -215,25 +215,25 @@
 <!-- wp:column {"verticalAlignment":"center"} -->
 <div class="wp-block-column is-vertically-aligned-center"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"align":"left","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"custom-borders","fontSize":"large"} -->
-<p class="has-text-align-left has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0">✳︎</p>
+<p class="has-text-align-left has-custom-borders-color has-text-color has-link-color has-large-font-size" style="padding-right:0;padding-left:0"><?php echo esc_html__( '✳︎', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3,"fontSize":"large"} -->
-<h3 class="wp-block-heading has-large-font-size">Études Newsletter</h3>
+<h3 class="wp-block-heading has-large-font-size"><?php echo esc_html__( 'Études Newsletter', 'twentytwentyfour' ); ?></h3>
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:paragraph -->
-<p><strong>✓</strong> Dive into a world of thought-provoking articles</p>
+<p><strong><?php echo esc_html__( '✓', 'twentytwentyfour' ); ?></strong>&nbsp;<?php echo esc_html__( 'Dive into a world of thought-provoking articles', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><strong>✓</strong> Read case studies that celebrate the artistry of architecture</p>
+<p><strong><?php echo esc_html__( '✓', 'twentytwentyfour' ); ?></strong>&nbsp;<?php echo esc_html__( 'Read case studies that celebrate the artistry of architecture', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><strong>✓</strong> Gain exclusive access to design insights</p>
+<p><strong><?php echo esc_html__( '✓', 'twentytwentyfour' ); ?></strong>&nbsp;<?php echo esc_html__( 'Gain exclusive access to design insights', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
@@ -243,7 +243,7 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"12vh","bottom":"12vh","left":"6vw","right":"6vw"}},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"backgroundColor":"contrast","textColor":"base","layout":{"type":"constrained"}} -->
 <div class="wp-block-group has-base-color has-contrast-background-color has-text-color has-background has-link-color" style="padding-top:12vh;padding-right:6vw;padding-bottom:12vh;padding-left:6vw"><!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
 <div class="wp-block-group alignwide"><!-- wp:paragraph {"align":"center","style":{"typography":{"lineHeight":"1.2","letterSpacing":"-0.02em"}},"fontSize":"x-large","fontFamily":"cardo"} -->
-<p class="has-text-align-center has-cardo-font-family has-x-large-font-size" style="letter-spacing:-0.02em;line-height:1.2"><em>“Études has saved us thousands of hours of work and has unlocked insights we never thought possible.”</em></p>
+<p class="has-text-align-center has-cardo-font-family has-x-large-font-size" style="letter-spacing:-0.02em;line-height:1.2"><em><?php echo esc_html__( '“Études has saved us thousands of hours of work and has unlocked insights we never thought possible.”', 'twentytwentyfour' ); ?></em></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
@@ -253,18 +253,18 @@
 <!-- /wp:image -->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.9rem"}}} -->
-<p style="font-size:0.9rem"><strong>Annie Steiner</strong></p>
+<p style="font-size:0.9rem"><strong><?php echo esc_html__( 'Annie Steiner', 'twentytwentyfour' ); ?></strong></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}},"typography":{"fontSize":"0.9rem"}},"textColor":"secondary"} -->
-<p class="has-secondary-color has-text-color has-link-color" style="font-size:0.9rem">CEO, Greenprint</p>
+<p class="has-secondary-color has-text-color has-link-color" style="font-size:0.9rem"><?php echo esc_html__( 'CEO, Greenprint', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"8vh","bottom":"8vh"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-top:8vh;padding-bottom:8vh"><!-- wp:heading {"align":"wide"} -->
-<h2 class="wp-block-heading alignwide">Watch, Read, Listen</h2>
+<h2 class="wp-block-heading alignwide"><?php echo esc_html__( 'Watch, Read, Listen', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|70"}}}} -->
@@ -281,7 +281,7 @@
 <div class="wp-block-group" style="padding-top:0;padding-bottom:0"><!-- wp:post-date {"format":"M j, Y"} /-->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} -->
-<p class="has-secondary-color has-text-color has-link-color">—</p>
+<p class="has-secondary-color has-text-color has-link-color"><?php echo esc_html__( '—', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:post-author-name /-->
@@ -309,7 +309,7 @@
 <div class="wp-block-group" style="padding-top:0;padding-bottom:0"><!-- wp:post-date {"format":"M j, Y"} /-->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} -->
-<p class="has-secondary-color has-text-color has-link-color">—</p>
+<p class="has-secondary-color has-text-color has-link-color"><?php echo esc_html__( '—', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:post-author-name /-->
@@ -329,16 +329,16 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"8vh","bottom":"8vh"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-top:8vh;padding-bottom:8vh"><!-- wp:group {"align":"wide","style":{"border":{"radius":"16px"},"spacing":{"padding":{"top":"6vh","bottom":"6vh","left":"6vw","right":"6vw"}}},"backgroundColor":"tertiary","layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 <div class="wp-block-group alignwide has-tertiary-background-color has-background" style="border-radius:16px;padding-top:6vh;padding-right:6vw;padding-bottom:6vh;padding-left:6vw"><!-- wp:heading {"textAlign":"center"} -->
-<h2 class="wp-block-heading has-text-align-center">Join 900+ subscribers</h2>
+<h2 class="wp-block-heading has-text-align-center"><?php echo esc_html__( 'Join 900+ subscribers', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center">Stay in the loop with everything you need to know.</p>
+<p class="has-text-align-center"><?php echo esc_html__( 'Stay in the loop with everything you need to know.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Sign Up</a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo esc_html__( 'Sign Up', 'twentytwentyfour' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group --></div>

--- a/patterns/sidebar-writer.php
+++ b/patterns/sidebar-writer.php
@@ -13,11 +13,11 @@
 <!-- /wp:image -->
 
 <!-- wp:heading {"style":{"typography":{"fontSize":"1.4rem"}}} -->
-<h2 class="wp-block-heading" style="font-size:1.4rem">Sur l'auteur</h2>
+<h2 class="wp-block-heading" style="font-size:1.4rem"><?php echo esc_html__( 'Sur l\'auteur', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.9rem"}}} -->
-<p style="font-size:0.9rem">Je suis Adele Diouf, et je suis animée par une curiosité insatiable de dévoiler la tapisserie complexe de la finance et de l'économie. Au cours de plus d'une décennie, mon voyage à travers le labyrinthe des marchés mondiaux, des politiques monétaires et des tendances économiques a fourni aux lecteurs les outils nécessaires pour naviguer dans le paysage dynamique de la finance.</p>
+<p style="font-size:0.9rem"><?php echo esc_html__( 'Je suis Adele Diouf, et je suis animée par une curiosité insatiable de dévoiler la tapisserie complexe de la finance et de l\'économie. Au cours de plus d\'une décennie, mon voyage à travers le labyrinthe des marchés mondiaux, des politiques monétaires et des tendances économiques a fourni aux lecteurs les outils nécessaires pour naviguer dans le paysage dynamique de la finance.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
@@ -26,7 +26,7 @@
 <!-- /wp:separator -->
 
 <!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
-<h2 class="wp-block-heading" style="font-size:1.6rem">Derniers articles</h2>
+<h2 class="wp-block-heading" style="font-size:1.6rem"><?php echo esc_html__( 'Derniers articles', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:query {"queryId":13,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
@@ -38,7 +38,7 @@
 <div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y"} /-->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"},"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} -->
-<p class="has-secondary-color has-text-color has-link-color" style="font-size:0.8rem">—</p>
+<p class="has-secondary-color has-text-color has-link-color" style="font-size:0.8rem"><?php echo esc_html__( '—', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:post-author-name /-->
@@ -60,21 +60,21 @@
 <!-- wp:group {"style":{"spacing":{"blockGap":"1.6rem"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"0.3rem"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
-<h2 class="wp-block-heading" style="font-size:1.6rem">Des connections utiles</h2>
+<h2 class="wp-block-heading" style="font-size:1.6rem"><?php echo esc_html__( 'Des connections utiles', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.9rem"}}} -->
-<p style="font-size:0.9rem">Des choses que je trouve utiles et que je voulais partager avec vous.</p>
+<p style="font-size:0.9rem"><?php echo esc_html__( 'Des choses que je trouve utiles et que je voulais partager avec vous.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"0.6rem"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"style":{"typography":{"fontSize":"0.9rem"}}} -->
-<p style="font-size:0.9rem"><a href="https://tt4writer.mystagingwebsite.com">Dernier rapport sur l'inflation </a>↗</p>
+<p style="font-size:0.9rem"><a href="https://tt4writer.mystagingwebsite.com"><?php echo esc_html__( 'Dernier rapport sur l\'inflation', 'twentytwentyfour' ); ?></a><?php echo esc_html__( '↗', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.9rem"}}} -->
-<p style="font-size:0.9rem"><a href="https://tt4writer.mystagingwebsite.com">Applications financières pour les familles </a>↗</p>
+<p style="font-size:0.9rem"><a href="https://tt4writer.mystagingwebsite.com"><?php echo esc_html__( 'Applications financières pour les familles', 'twentytwentyfour' ); ?></a><?php echo esc_html__( '↗', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>

--- a/patterns/sidebar.php
+++ b/patterns/sidebar.php
@@ -38,7 +38,7 @@
 <div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y"} /-->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"},"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary"} -->
-<p class="has-secondary-color has-text-color has-link-color" style="font-size:0.8rem">—</p>
+<p class="has-secondary-color has-text-color has-link-color" style="font-size:0.8rem"><?php echo esc_html__( '—', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:post-author-name /-->


### PR DESCRIPTION
Applies escaping functions patterns currently present in the theme.

Fixes: https://github.com/WordPress/twentytwentyfour/issues/97, https://github.com/WordPress/twentytwentyfour/issues/91, https://github.com/WordPress/twentytwentyfour/issues/82, https://github.com/WordPress/twentytwentyfour/issues/62, https://github.com/WordPress/twentytwentyfour/issues/37

The changes were made using a script, adapted from https://github.com/Automattic/themes/blob/trunk/theme-utils.mjs

Adapted script source: https://gist.github.com/vcanales/1df0cd9fe27c5823ca987536e68ecce0 — it isn't perfect; it failed to detect some already translated strings, which I fixed manually.

Also, shameless plug, if you want to speed up your workflow when adding escaping functions, see this post I wrote on using vscode snippets: https://canales.io/2023/07/20/streamlining-your-coding-workflow-with-vs-code-snippets/