### PR TITLE
Fix: Block Patterns - Landing Page Background Color Issue

### DIFF
--- a/patterns/landing-page-cta.php
+++ b/patterns/landing-page-cta.php
@@ -7,8 +7,8 @@
 
 ?>
 
-<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"300px","bottom":"300px","left":"80px","right":"80px"},"blockGap":"20px"}},"backgroundColor":"custom-brick","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide has-custom-brick-background-color has-background" style="padding-top:300px;padding-right:80px;padding-bottom:300px;padding-left:80px"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"300px","bottom":"300px","left":"80px","right":"80px"},"blockGap":"20px"}},"backgroundColor":"accent-3","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide has-accent-3-background-color has-background" style="padding-top:300px;padding-right:80px;padding-bottom:300px;padding-left:80px"><!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:image {"align":"center","id":8,"width":45,"height":49,"scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
 <figure class="wp-block-image aligncenter size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/message_icon.png" alt="" class="wp-image-8" style="object-fit:cover;width:45px;height:49px" width="45" height="49"/></figure>
 <!-- /wp:image -->


### PR DESCRIPTION
Landing Page Block Patterns Already Have On Trunk. 
Related #121

I fixed the background-color custom-brick to accent-3 

### Screenshots
**Before Fix**
<img width="1400" alt="Screenshot 2023-08-29 at 4 31 43 PM" src="https://github.com/WordPress/twentytwentyfour/assets/63150399/727b2b07-7636-4565-8691-06d651e4a83b">

**After Fix**
<img width="1434" alt="Screenshot 2023-08-29 at 4 29 24 PM" src="https://github.com/WordPress/twentytwentyfour/assets/63150399/18fc9afa-c440-429c-965c-ae2d2afeb466">

