### PR TITLE
Fix accent-3 to match Figma

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -45,7 +45,7 @@
 					"slug": "accent-2"
 				},
 				{
-					"color": "#d26e57",
+					"color": "#d8613c",
 					"name": "Accent / Three",
 					"slug": "accent-3"
 				},


### PR DESCRIPTION
**Description**
Fix color for accent-3, to map to Figma. 

**Screenshots**

Before: 
<img width="121" alt="CleanShot 2023-08-29 at 12 11 48" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/ed7a5d56-f04b-4845-96a4-e449ff77d7e1">

After: 
<img width="121" alt="CleanShot 2023-08-29 at 12 11 28" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/ed273a83-f1f9-4a3c-8cc4-4a1f70bfbabc">
