### PR TITLE
Fixes #146 Footer text "Designed with" is not visible.

### DIFF
--- a/parts/footer-copy.html
+++ b/parts/footer-copy.html
@@ -59,7 +59,7 @@
 <!-- /wp:spacer -->
 
 <!-- wp:paragraph {"align":"left","style":{"typography":{"fontSize":"0.8rem"},"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast-2"} -->
-<p class="has-text-align-left has-base-2-color has-text-color has-link-color" style="font-size:0.8rem">Designed with <a rel="nofollow" href="https://wordpress.org">WordPress</a></p>
+<p class="has-text-align-left has-text-color has-link-color" style="font-size:0.8rem">Designed with <a rel="nofollow" href="https://wordpress.org">WordPress</a></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
Fixes #146 Footer text "Designed with" is not visible.

Fixed the issue by removing the _has-base-2-color_ css class as suggested.

<!-- Provide steps for testing -->
<!-- 1. Activate the theme. -->
<!-- 2. Visit the archives page. -->
<!-- 3. etc. -->
