### PR TITLE
A11y fix: adds a checkmark block style for lists and replaces it in `home.php`

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -54,3 +54,27 @@ if ( ! function_exists( 'twentytwentyfour_styles' ) ) :
 endif;
 
 add_action( 'wp_enqueue_scripts', 'twentytwentyfour_styles' );
+
+if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
+
+	/**
+	 * Register custom block styles
+	 *
+	 * @since Twenty Twenty-Four 1.0
+	 *
+	 * @return void
+	 */
+	function twentytwentyfour_block_styles() {
+		register_block_style(
+			'core/list',
+			array(
+				'name'         => 'checkmark-list',
+				'label'        => __( 'Checkmarks', 'twentytwentyfour' ),
+				'is_default'   => false,
+			)
+		);
+	}
+
+endif;
+
+add_action( 'init', 'twentytwentyfour_block_styles' );

--- a/functions.php
+++ b/functions.php
@@ -65,6 +65,8 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 	 * @return void
 	 */
 	function twentytwentyfour_block_styles() {
+
+		// Register a custom Checkmark style for the list block.
 		register_block_style(
 			'core/list',
 			array(

--- a/functions.php
+++ b/functions.php
@@ -72,7 +72,6 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 			array(
 				'name'         => 'checkmark-list',
 				'label'        => __( 'Checkmarks', 'twentytwentyfour' ),
-				'is_default'   => false,
 			)
 		);
 	}

--- a/patterns/home.php
+++ b/patterns/home.php
@@ -180,7 +180,7 @@
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 
-<!-- wp:list {"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"className":"is-style-checkmark-list"} -->
+<!-- wp:list {"style":{"spacing":{"padding":{"right":"0","left":"var:preset|spacing|10"}}},"className":"is-style-checkmark-list"} -->
 <ul class="is-style-checkmark-list" style="padding-right:0;padding-left:0"><!-- wp:list-item -->
 <li>Collaborate with fellow architects</li>
 <!-- /wp:list-item -->
@@ -224,7 +224,7 @@
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 
-<!-- wp:list {"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"className":"is-style-checkmark-list"} -->
+<!-- wp:list {"style":{"spacing":{"padding":{"right":"0","left":"var:preset|spacing|10"}}},"className":"is-style-checkmark-list"} -->
 <ul class="is-style-checkmark-list" style="padding-right:0;padding-left:0"><!-- wp:list-item -->
 <li>Dive into a world of thought-provoking articles</li>
 <!-- /wp:list-item -->

--- a/patterns/home.php
+++ b/patterns/home.php
@@ -180,8 +180,8 @@
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 
-<!-- wp:list {"style":{"spacing":{"padding":{"right":"0","left":"var:preset|spacing|10"}}},"className":"is-style-checkmark-list"} -->
-<ul class="is-style-checkmark-list" style="padding-right:0;padding-left:0"><!-- wp:list-item -->
+<!-- wp:list {"style":{"spacing":{"padding":{"right":"0","left":"var:preset|spacing|10"},"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"className":"is-style-checkmark-list"} -->
+<ul class="is-style-checkmark-list" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30);padding-right:0;padding-left:var(--wp--preset--spacing--10)"><!-- wp:list-item -->
 <li>Collaborate with fellow architects</li>
 <!-- /wp:list-item -->
 
@@ -224,8 +224,8 @@
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 
-<!-- wp:list {"style":{"spacing":{"padding":{"right":"0","left":"var:preset|spacing|10"}}},"className":"is-style-checkmark-list"} -->
-<ul class="is-style-checkmark-list" style="padding-right:0;padding-left:0"><!-- wp:list-item -->
+<!-- wp:list {"style":{"spacing":{"padding":{"right":"0","left":"var:preset|spacing|10"},"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"className":"is-style-checkmark-list"} -->
+<ul class="is-style-checkmark-list" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30);padding-right:0;padding-left:var(--wp--preset--spacing--10)"><!-- wp:list-item -->
 <li>Dive into a world of thought-provoking articles</li>
 <!-- /wp:list-item -->
 

--- a/patterns/home.php
+++ b/patterns/home.php
@@ -180,19 +180,19 @@
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:paragraph -->
-<p><strong><?php echo esc_html__( '✓', 'twentytwentyfour' ); ?></strong>&nbsp;<?php echo esc_html__( 'Collaborate with fellow architects', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph -->
+<!-- wp:list {"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"className":"is-style-checkmark-list"} -->
+<ul class="is-style-checkmark-list" style="padding-right:0;padding-left:0"><!-- wp:list-item -->
+<li>Collaborate with fellow architects</li>
+<!-- /wp:list-item -->
 
-<!-- wp:paragraph -->
-<p><strong><?php echo esc_html__( '✓', 'twentytwentyfour' ); ?></strong>&nbsp;<?php echo esc_html__( 'Showcase your projects', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph -->
+<!-- wp:list-item -->
+<li>Showcase your projects</li>
+<!-- /wp:list-item -->
 
-<!-- wp:paragraph -->
-<p><strong><?php echo esc_html__( '✓', 'twentytwentyfour' ); ?></strong>&nbsp;<?php echo esc_html__( 'Experience the world of architecture like never before', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
+<!-- wp:list-item -->
+<li>Experience the world of architecture like never before</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->

--- a/patterns/home.php
+++ b/patterns/home.php
@@ -224,19 +224,19 @@
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:paragraph -->
-<p><strong><?php echo esc_html__( '✓', 'twentytwentyfour' ); ?></strong>&nbsp;<?php echo esc_html__( 'Dive into a world of thought-provoking articles', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph -->
+<!-- wp:list {"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"className":"is-style-checkmark-list"} -->
+<ul class="is-style-checkmark-list" style="padding-right:0;padding-left:0"><!-- wp:list-item -->
+<li>Dive into a world of thought-provoking articles</li>
+<!-- /wp:list-item -->
 
-<!-- wp:paragraph -->
-<p><strong><?php echo esc_html__( '✓', 'twentytwentyfour' ); ?></strong>&nbsp;<?php echo esc_html__( 'Read case studies that celebrate the artistry of architecture', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph -->
+<!-- wp:list-item -->
+<li>Read case studies that celebrate the artistry of architecture</li>
+<!-- /wp:list-item -->
 
-<!-- wp:paragraph -->
-<p><strong><?php echo esc_html__( '✓', 'twentytwentyfour' ); ?></strong>&nbsp;<?php echo esc_html__( 'Gain exclusive access to design insights', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
+<!-- wp:list-item -->
+<li>Gain exclusive access to design insights</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
 <!-- /wp:group -->

--- a/patterns/left-aligned-cta-image.php
+++ b/patterns/left-aligned-cta-image.php
@@ -13,8 +13,8 @@
 <h2 class="wp-block-heading"><?php echo esc_html__( 'Enhance your architectural journey with the Études Architect App', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:list {"style":{"spacing":{"padding":{"left":"var:preset|spacing|10"}}},"className":"is-style-checkmark-list"} -->
-<ul class="is-style-checkmark-list" style="padding-left:var(--wp--preset--spacing--10)"><!-- wp:list-item -->
+<!-- wp:list {"style":{"spacing":{"padding":{"left":"var:preset|spacing|10"},"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"className":"is-style-checkmark-list"} -->
+<ul class="is-style-checkmark-list" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--10)"><!-- wp:list-item -->
 <li>Collaborate with fellow architects</li>
 <!-- /wp:list-item -->
 

--- a/patterns/left-aligned-cta-image.php
+++ b/patterns/left-aligned-cta-image.php
@@ -13,17 +13,17 @@
 <h2 class="wp-block-heading"><?php echo esc_html__( 'Enhance your architectural journey with the Études Architect App', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:list {"style":{"typography":{"lineHeight":"1.75"}}} -->
-<ul style="line-height:1.75"><!-- wp:list-item -->
-<li><?php echo esc_html__( 'Collaborate with fellow architects', 'twentytwentyfour' ); ?></li>
+<!-- wp:list {"style":{"spacing":{"padding":{"left":"var:preset|spacing|10"}}},"className":"is-style-checkmark-list"} -->
+<ul class="is-style-checkmark-list" style="padding-left:var(--wp--preset--spacing--10)"><!-- wp:list-item -->
+<li>Collaborate with fellow architects</li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><?php echo esc_html__( 'Showcase your projects', 'twentytwentyfour' ); ?></li>
+<li>Showcase your projects</li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><?php echo esc_html__( 'Experience the world of architecture like never before', 'twentytwentyfour' ); ?></li>
+<li>Experience the world of architecture like never before</li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 

--- a/style.css
+++ b/style.css
@@ -33,3 +33,19 @@ a {
 	text-decoration-thickness: .0625em !important;
 	text-underline-offset: .15em;
 }
+
+/*
+ * Styles for the custom checkmark list block style
+ * https://github.com/WordPress/twentytwentyfour/issues/46
+ */
+.wp-block-list.is-style-checkmark-list {
+	list-style-type: "✓";
+}
+
+.wp-block-list.is-style-checkmark-list li::marker {
+	font-weight: bold;
+}
+
+.wp-block-list.is-style-checkmark-list li {
+	padding-inline-start: 1ch;
+}

--- a/style.css
+++ b/style.css
@@ -47,5 +47,5 @@ a {
 }
 
 .wp-block-list.is-style-checkmark-list li {
-	padding-inline-start: 1ch;
+	padding-inline-start: 0.5ch;
 }

--- a/style.css
+++ b/style.css
@@ -40,6 +40,9 @@ a {
  */
 .wp-block-list.is-style-checkmark-list {
 	list-style-type: "✓";
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
 }
 
 .wp-block-list.is-style-checkmark-list li::marker {
@@ -47,5 +50,5 @@ a {
 }
 
 .wp-block-list.is-style-checkmark-list li {
-	padding-inline-start: 0.5ch;
+	padding-inline-start: 1ch;
 }

--- a/style.css
+++ b/style.css
@@ -38,17 +38,18 @@ a {
  * Styles for the custom checkmark list block style
  * https://github.com/WordPress/twentytwentyfour/issues/46
  */
-.wp-block-list.is-style-checkmark-list {
+ul.is-style-checkmark-list {
 	list-style-type: "✓";
-	display: flex;
-	flex-direction: column;
-	gap: 1rem;
 }
 
-.wp-block-list.is-style-checkmark-list li::marker {
+ul.is-style-checkmark-list li::marker {
 	font-weight: bold;
 }
 
-.wp-block-list.is-style-checkmark-list li {
+ul.is-style-checkmark-list li {
 	padding-inline-start: 1ch;
+}
+
+ul.is-style-checkmark-list > li + li {
+	margin-block-start: 1rem;
 }


### PR DESCRIPTION
Closes #46.

**Description**

Right now there's a list pattern used in the home template for TT4 that uses paragraphs with checkmarks to simulate a list. This is an accessibility issue as described in #46:

> 1. This doesn't convey to Screen Readers that the content is in a list or the number of list items in each list.
> 2. Checkmarks are read out loud as "checkmark" by the screenreader.

This PR registers a new custom block style for Lists called `Checkmarks` to fix that issue.

**Screenshots**

Desktop view:

<img width="1198" alt="desktop view of the new checkmark list style in place on the homepage template" src="https://github.com/WordPress/twentytwentyfour/assets/6925260/54a16945-02fc-4312-81f1-81304296b538">

Mobile view:
<img width="359" alt="mobile view of the new checkmark list style in place on the homepage template" src="https://github.com/WordPress/twentytwentyfour/assets/6925260/4b1da062-226d-46de-bf2d-25c16834b4e4">


Design discussion/question:
- the original design has considerable gap between the list items since they were paragraphs. Do we want to add spacing between list items when they are in this checkmark style or leave it be?


**Testing Instructions**

<!-- Provide steps for testing -->
1. Activate the theme. -->
2. Create a new post or page.
3. Add a list and choose the checkmark list style.
