### PR TITLE
fix: add date and author archive links to the 'home' pattern

### DIFF
--- a/parts/post-meta.html
+++ b/parts/post-meta.html
@@ -1,12 +1,12 @@
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex"}} -->
-<div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y","isLink":true} /-->
+<div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y"} /-->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
 <p class="has-base-2-color has-text-color has-link-color">—</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:post-author-name {"isLink":true} /-->
+<!-- wp:post-author-name /-->
 
 <!-- wp:post-terms {"term":"category","prefix":"in ","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast-2"} /--></div>
 <!-- /wp:group --></div>

--- a/parts/post-meta.html
+++ b/parts/post-meta.html
@@ -1,12 +1,12 @@
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex"}} -->
-<div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y"} /-->
+<div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y","isLink":true} /-->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
 <p class="has-base-2-color has-text-color has-link-color">—</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:post-author-name /-->
+<!-- wp:post-author-name {"isLink":true} /-->
 
 <!-- wp:post-terms {"term":"category","prefix":"in ","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast-2"} /--></div>
 <!-- /wp:group --></div>

--- a/patterns/home.php
+++ b/patterns/home.php
@@ -279,13 +279,13 @@
 <div class="wp-block-group"><!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"0.3em","padding":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
-<div class="wp-block-group" style="padding-top:0;padding-bottom:0"><!-- wp:post-date {"format":"M j, Y"} /-->
+<div class="wp-block-group" style="padding-top:0;padding-bottom:0"><!-- wp:post-date {"format":"M j, Y","isLink":true} /-->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
 <p class="has-base-2-color has-text-color has-link-color"><?php echo esc_html__( '—', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:post-author-name /-->
+<!-- wp:post-author-name {"isLink":true} /-->
 
 <!-- wp:post-terms {"term":"category","prefix":"in ","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast-2"} /--></div>
 <!-- /wp:group -->
@@ -307,13 +307,13 @@
 <div class="wp-block-group"><!-- wp:post-title {"isLink":true,"style":{"typography":{"fontSize":"1.7rem"}}} /-->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"0.3em","padding":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
-<div class="wp-block-group" style="padding-top:0;padding-bottom:0"><!-- wp:post-date {"format":"M j, Y"} /-->
+<div class="wp-block-group" style="padding-top:0;padding-bottom:0"><!-- wp:post-date {"format":"M j, Y","isLink":true} /-->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
 <p class="has-base-2-color has-text-color has-link-color"><?php echo esc_html__( '—', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:post-author-name /-->
+<!-- wp:post-author-name {"isLink":true} /-->
 
 <!-- wp:post-terms {"term":"category","prefix":"in ","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast-2"} /--></div>
 <!-- /wp:group -->


### PR DESCRIPTION
**Description**

Currently the date and author archive links missing in `patterns/home.php`, This PR adds the `isLink` attributes for the `wp:post-author-name` and `wp:post-date` blocks.

resolves #154 

**Screenshots**

![image](https://github.com/WordPress/twentytwentyfour/assets/30468274/4ac71dac-df00-45d1-8db1-809ffeea5cd8)

**Testing Instructions**

1. Setup the new '[twentytwentyfour](https://github.com/alaminfirdows/twentytwentyfour/tree/fix/date-and-author-links)' theme from the forked repository
2. Go the the 'Watch, Read, Listen' Section
3. Hover over the post date or author name
