### PR TITLE
fix: apply `contrast-2` for button and post meta section

### DIFF
--- a/patterns/home.php
+++ b/patterns/home.php
@@ -18,7 +18,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"contrast"} -->
 <div class="wp-block-button"><a class="wp-block-button__link wp-element-button has-background has-contrast-background-color"><?php echo esc_html__( 'Learn More', 'twentytwentyfour' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>

--- a/patterns/home.php
+++ b/patterns/home.php
@@ -19,7 +19,7 @@
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo esc_html__( 'Learn More', 'twentytwentyfour' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button has-background has-contrast-background-color"><?php echo esc_html__( 'Learn More', 'twentytwentyfour' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group -->
@@ -282,7 +282,7 @@
 <div class="wp-block-group" style="padding-top:0;padding-bottom:0"><!-- wp:post-date {"format":"M j, Y"} /-->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
-<p class="has-base-2-color has-text-color has-link-color"><?php echo esc_html__( '—', 'twentytwentyfour' ); ?></p>
+<p class="has-contrast-2-color has-text-color has-link-color"><?php echo esc_html__( '—', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:post-author-name /-->
@@ -310,7 +310,7 @@
 <div class="wp-block-group" style="padding-top:0;padding-bottom:0"><!-- wp:post-date {"format":"M j, Y"} /-->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
-<p class="has-base-2-color has-text-color has-link-color"><?php echo esc_html__( '—', 'twentytwentyfour' ); ?></p>
+<p class="has-contrast-2-color has-text-color has-link-color"><?php echo esc_html__( '—', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:post-author-name /-->


### PR DESCRIPTION
**Description**

I found that the `home.php` pattern has missed some CSS class name for hero area button and blog post meta separator. This PR fixes the color issues by adding the `contrast-2` color class names.

resolves #153

**Screenshots**

![Group 18](https://github.com/WordPress/twentytwentyfour/assets/30468274/225791a1-8097-4209-a7db-d35c06f586fc)

![Group 19](https://github.com/WordPress/twentytwentyfour/assets/30468274/320d501e-6cfd-4333-8e8f-f5f83f8ccbc3)


**Testing Instructions**

1. Setup the new '[twentytwentyfour](https://github.com/alaminfirdows/twentytwentyfour/tree/fix/contrast-color-issue)' theme from the forked repository
2. Go the the 'Site Editor'
3. Click on the 'Learn More' button and over out.