### PR TITLE
Update the default footer

### DIFF
--- a/parts/footer.html
+++ b/parts/footer.html
@@ -1,65 +1,22 @@
-<!-- wp:group {"style":{"border":{"top":{"color":"var:preset|color|base-3","width":"1px"},"right":[],"bottom":[],"left":[]}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--base-3);border-top-width:1px"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"7vh","bottom":"7vh"}}}} -->
-<div class="wp-block-group alignwide" style="padding-top:7vh;padding-bottom:7vh"><!-- wp:columns -->
-<div class="wp-block-columns"><!-- wp:column {"width":"30%"} -->
-<div class="wp-block-column" style="flex-basis:30%"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"style":{"typography":{"fontSize":"1.8rem"}}} -->
-<p style="font-size:1.8rem">✦</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:site-title {"level":0} /-->
-
-<!-- wp:site-tagline /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:column -->
-
-<!-- wp:column {"width":"40%"} -->
-<div class="wp-block-column" style="flex-basis:40%"></div>
-<!-- /wp:column -->
-
-<!-- wp:column {"width":"30%"} -->
-<div class="wp-block-column" style="flex-basis:30%"><!-- wp:columns {"isStackedOnMobile":false} -->
-<div class="wp-block-columns is-not-stacked-on-mobile"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","padding":{"top":"var:preset|spacing|70"}},"typography":{"fontSize":"0.8rem"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--70);font-size:0.8rem"><!-- wp:paragraph {"style":{"typography":{"fontSize":"0.9rem","fontStyle":"normal","fontWeight":"500"}}} -->
-<p style="font-size:0.9rem;font-style:normal;font-weight:500">Home</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.9rem","fontStyle":"normal","fontWeight":"500"}}} -->
-<p style="font-size:0.9rem;font-style:normal;font-weight:500">Pages</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.9rem","fontStyle":"normal","fontWeight":"500"}}} -->
-<p style="font-size:0.9rem;font-style:normal;font-weight:500">Posts</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:column -->
-
-<!-- wp:column -->
-<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","padding":{"top":"var:preset|spacing|70"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--70)"><!-- wp:paragraph {"style":{"typography":{"fontSize":"0.9rem","fontStyle":"normal","fontWeight":"500"}}} -->
-<p style="font-size:0.9rem;font-style:normal;font-weight:500">Patterns</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.9rem","fontStyle":"normal","fontWeight":"500"}}} -->
-<p style="font-size:0.9rem;font-style:normal;font-weight:500">Templates</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.9rem","fontStyle":"normal","fontWeight":"500"}}} -->
-<p style="font-size:0.9rem;font-style:normal;font-weight:500">Contact</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->
-
-<!-- wp:spacer {"height":"7vh"} -->
-<div style="height:7vh" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:paragraph {"align":"left","style":{"typography":{"fontSize":"0.8rem"},"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast-2"} -->
-<p class="has-text-align-left has-base-2-color has-text-color has-link-color" style="font-size:0.8rem">Designed with <a rel="nofollow" href="https://wordpress.org">WordPress</a></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
+<!-- wp:group {"layout":{"type":"default"},"style":{"spacing":{"padding":{"top":"var(--wp--preset--spacing--50)"}}}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);">
+	<!-- wp:group {"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group">
+		<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"top"}} -->
+		<div class="wp-block-group alignwide">
+			<!-- wp:group {"style":{"dimensions":{"minHeight":""},"layout":{"selfStretch":"fit","flexSize":null}},"layout":{"type":"flex","orientation":"vertical"}} -->
+			<div class="wp-block-group">
+				<!-- wp:site-logo /-->
+				<!-- wp:site-title {"level":0} /-->
+				<!-- wp:site-tagline /-->
+			</div>
+			<!-- /wp:group -->
+			<!-- wp:navigation {"ref":4,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"small"} /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+</div>
 <!-- /wp:group -->
+
+<!-- wp:pattern {"slug":"twentytwentyfour/footer"} /-->

--- a/parts/footer.html
+++ b/parts/footer.html
@@ -11,7 +11,7 @@
 				<!-- wp:site-tagline /-->
 			</div>
 			<!-- /wp:group -->
-			<!-- wp:navigation {"ref":4,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"small"} /-->
+			<!-- wp:navigation {"ref":4,"overlayMenu":"never","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"small"} /-->
 		</div>
 		<!-- /wp:group -->
 	</div>

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -7,16 +7,12 @@
  */
 ?>
 
-<!-- wp:spacer {"height":"var(--wp--preset--spacing--80)"} -->
-<div style="height:var(--wp--preset--spacing--80)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
-	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var(--wp--preset--spacing--60)","bottom":"var(--wp--preset--spacing--60)"}}}} -->
-	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
-		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center">
+	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var(--wp--preset--spacing--60)","bottom":"var(--wp--preset--spacing--50)"}}}} -->
+	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--50)">
+		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast-2","fontSize":"small"} -->
+		<p class="has-contrast-2-color has-text-color has-link-color has-small-font-size">
 			<?php
 				/* Translators: WordPress link. */
 				$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfour' ) ) . '" rel="nofollow">WordPress</a>';


### PR DESCRIPTION
**Description**
Updates the default footer using a site logo instead of the paragraph and a horizontal navigation block instead of the fake menu with two columns.
Uses the footer.php block pattern for the footer credit text.

**Testing Instructions**
Reset any saved changes to templates and template parts.
If needed, assign a menu to the navigation block in the footer.
If needed, assign a site logo to the site logo block.
View the updated footer in the Site Editor and on the front.
