### PR TITLE
Add contributor reminder to PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,3 +12,7 @@
 <!-- 1. Activate the theme. -->
 <!-- 2. Visit the archives page. -->
 <!-- 3. etc. -->
+
+**Contributors**
+
+<!-- Please ensure anyone who contributed on linked issues and within this pull request have _AT LEAST_ their GitHub Username listed in the `CONTRIBUTORS.md` file as part of this PR. -->


### PR DESCRIPTION
**Description**

This adds a section to the PR template to remind folks to ensure we're capturing all viable contributors and updating `CONTRIBUTORS.md` accordingly in PRs.  This will ensure the final merge to core will get those folks credited as part of the WordPress 6.4 release.

**Screenshots**

Not a visible theme change, n/a.

**Testing Instructions**

Not a functional change, n/a.