### PR TITLE
Add centered call to action

### DIFF
--- a/patterns/cta.php
+++ b/patterns/cta.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Title: Centered Call To Action
+ * Slug: twentytwentyfour/cta
+ * Categories: call-to-action
+ */
+
+?>
+
+<!-- wp:group {"align":"wide","style":{"border":{"radius":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"backgroundColor":"base-2","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+	<!-- wp:heading {"textAlign":"center"} -->
+	<h2 class="wp-block-heading has-text-align-center"><?php echo esc_html_x( 'Join 900+ designers', 'Heading of the Call to Action', 'twentytwentyfour' ); ?></h2>
+	<!-- /wp:heading -->
+	<!-- wp:paragraph {"align":"center"} -->
+	<p class="has-text-align-center"><?php echo esc_html_x( 'Stay in the loop with everything you need to know', 'Description of the Call to Action', 'twentytwentyfour' ); ?></p>
+	<!-- /wp:paragraph -->
+	<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+	<div class="wp-block-buttons"><!-- wp:button -->
+	<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Sign up', 'Call to Action button text', 'twentytwentyfour' ); ?></a></div>
+	<!-- /wp:button --></div>
+	<!-- /wp:buttons -->
+</div>
+<!-- /wp:group -->


### PR DESCRIPTION
**Description**

This PR replaces https://github.com/WordPress/twentytwentyfour/pull/43 and closes https://github.com/WordPress/twentytwentyfour/issues/114

**Screenshots**

<img width="652" alt="Call to action with heading, paragraph, and button" src="https://github.com/WordPress/twentytwentyfour/assets/7422055/a607eafd-217d-4a70-a49d-8a3fe6a67af1">

**Testing Instructions**
Open the pattern inserter and select the "call to action" category. Locate and insert the pattern.

**Contributors**
Props @LynUrth
