### PR TITLE
Added contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,3 +37,9 @@
 | @devmuhib009 | @devmuhib |
 | @lynurth | @lyndauwp |
 | @kraftbj | @kraftbj |
+| @alaminfirdows | @alaminfirdows |
+| @LittleBigThing | @littlebigthing |
+| @dhamibirendra | dhamibirendra |
+| @jeffpaul | @jeffpaul |
+| @itsmekopila | @kopila47 |
+| @ernilambar | @rabmalin |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,7 +39,7 @@
 | @kraftbj | @kraftbj |
 | @alaminfirdows | @alaminfirdows |
 | @LittleBigThing | @littlebigthing |
-| @dhamibirendra | dhamibirendra |
+| @dhamibirendra | @dhamibirendra |
 | @jeffpaul | @jeffpaul |
 | @itsmekopila | @kopila47 |
 | @ernilambar | @rabmalin |


### PR DESCRIPTION
Added 6 new contributors whose PR are merged and listed in the GitHub contributor's list, https://github.com/WordPress/twentytwentyfour/graphs/contributors
