### PR TITLE
remove footer-copy template part from theme.json

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -764,11 +764,6 @@
 			"title": "Footer: Writer"
 		},
 		{
-			"area": "footer",
-			"name": "footer-copy",
-			"title": "Footer: Copy"
-		},
-		{
 			"area": "uncategorized",
 			"name": "sidebar",
 			"title": "Sidebar"


### PR DESCRIPTION
**Description**
In https://github.com/WordPress/twentytwentyfour/pull/167, I removed the file but forgot to remove it from theme.json.
