### PR TITLE
Try/image block border radius

### DIFF
--- a/patterns/about-2.php
+++ b/patterns/about-2.php
@@ -35,8 +35,8 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:image {"aspectRatio":"3/4","scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/tt4_about_1.jpg" alt="<?php esc_attr_e( 'Picture Of Business About', 'twentytwentyfour' ); ?>" style="aspect-ratio:3/4;object-fit:cover"/></figure>
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:image {"aspectRatio":"3/4","scale":"cover","sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
+<figure class="wp-block-image size-large is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/tt4_about_1.jpg" alt="<?php esc_attr_e( 'Picture Of Business About', 'twentytwentyfour' ); ?>" style="aspect-ratio:3/4;object-fit:cover"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>

--- a/patterns/project-description.php
+++ b/patterns/project-description.php
@@ -25,7 +25,7 @@
 <div style="margin-top:0;margin-bottom:0;height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:image {"align":"wide","sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image alignwide size-large"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/tt4_projectoverview_2-scaled-1.jpg" alt="<?php echo esc_attr( 'An women walking in the stair.', 'twentytwentyfour' ); ?>"/></figure>
+<!-- wp:image {"align":"wide","sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
+<figure class="wp-block-image alignwide size-large is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/tt4_projectoverview_2-scaled-1.jpg" alt="<?php echo esc_attr( 'An women walking in the stair.', 'twentytwentyfour' ); ?>"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->

--- a/patterns/services-cta.php
+++ b/patterns/services-cta.php
@@ -9,8 +9,8 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"contrast-3","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-contrast-3-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|40","left":"var:preset|spacing|50"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center","width":"60%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:60%"><!-- wp:image {"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/tt4_services_1.png" alt="<?php echo esc_attr( 'A man holding some paper', 'twentytwentyfour' ); ?>" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:60%"><!-- wp:image {"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-rounded"} -->
+<figure class="wp-block-image size-full is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/tt4_services_1.png" alt="<?php echo esc_attr( 'A man holding some paper', 'twentytwentyfour' ); ?>" style="aspect-ratio:4/3;object-fit:cover"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 

--- a/theme.json
+++ b/theme.json
@@ -395,7 +395,7 @@
 				"variations": {
 					"rounded": {
 						"border": {
-							"radius": "1rem"
+							"radius": "16px"
 						}
 					}
 				}

--- a/theme.json
+++ b/theme.json
@@ -395,7 +395,7 @@
 				"variations": {
 					"rounded": {
 						"border": {
-							"radius": "16px"
+							"radius": "var(--wp--preset--spacing--10)"
 						}
 					}
 				}

--- a/theme.json
+++ b/theme.json
@@ -391,6 +391,15 @@
 					}
 				}
 			},
+			"core/image": {
+				"variations": {
+					"rounded": {
+						"border": {
+							"radius": "1rem"
+						}
+					}
+				}
+			},
 			"core/list": {
 				"spacing": {
 					"padding": {


### PR DESCRIPTION
**Description**

Kick off exploration for solution to #199 

I recommend two steps for each pattern/template where images are used:

- [ ] Add the `is-style-rounded` in each pattern/template as a unique commit
- [ ] Verify that each corresponding image has no radius in original image file. Re-export if necessary (requires edit access to Figma file)

I recommend using `px` for `border-radius`. One of the few properties that I would recommend using `px` for, as opposed to type and spacing. Mostly, because `border-radius` is something we want consistency with and not different calculated values for.

Note: I did not re-export the image in my example pattern, because I do not have edit access to the Figma file and one cannot disable the border-radius applied to the image within Figma when attempting to re-export, unless they have edit access.

Also, I would follow add more commits to this to cover all images and patterns if we are happy with the approach.

An alternative approach is applying the border-radius on all Image blocks and not utilize the Rounded variation. Example of `theme.json`:

```
			"core/image": {
				"border": {
					"radius": "16px"
				}
			},
```

**Screenshots**

![Screenshot 2023-09-06 at 9 59 39 AM](https://github.com/WordPress/twentytwentyfour/assets/405912/4ca00deb-16db-427a-a64e-6db743e186e3)

**Testing Instructions**

Check out the 'Project description' pattern and `theme.json` entry for `core/image` block
