### PR TITLE
Make fluid spacing smaller on on mobile

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -112,32 +112,32 @@
 			"spacingSizes": [
 				{
 					"name": "1",
-					"size": "min(1rem, 2vw)",
+					"size": "min(1rem, 1vw)",
 					"slug": "10"
 				},
 				{
 					"name": "2",
-					"size": "min(1.5rem, 3vw)",
+					"size": "min(1.5rem, 2vw)",
 					"slug": "20"
 				},
 				{
 					"name": "3",
-					"size": "min(2.5rem, 5vw)",
+					"size": "min(2.5rem, 3vw)",
 					"slug": "30"
 				},
 				{
 					"name": "4",
-					"size": "min(4rem, 8vw)",
+					"size": "min(4rem, 5vw)",
 					"slug": "40"
 				},
 				{
 					"name": "5",
-					"size": "min(6.5rem, 13vw)",
+					"size": "min(6.5rem, 8vw)",
 					"slug": "50"
 				},
 				{
 					"name": "6",
-					"size": "min(10.5rem, 24vw)",
+					"size": "min(10.5rem, 13vw)",
 					"slug": "60"
 				}
 			],


### PR DESCRIPTION
Before: 
<img width="567" alt="CleanShot 2023-09-06 at 14 27 35" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/1a610ba4-a115-42b3-bda1-9b2533780bdb">


After: 

<img width="571" alt="CleanShot 2023-09-06 at 14 27 15" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/e17b4271-e9b4-449c-8c94-05e071b4e95e">
