### PR TITLE
Use preset radii

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -395,7 +395,7 @@
 				"variations": {
 					"rounded": {
 						"border": {
-							"radius": "var(--wp--preset--spacing--10)"
+							"radius": "var(--wp--preset--spacing--20)"
 						}
 					}
 				}
@@ -485,7 +485,7 @@
 			},
 			"core/post-featured-image": {
 				"border": {
-					"radius": "16px"
+					"radius": "var(--wp--preset--spacing--20)"
 				}
 			},
 			"core/post-terms": {
@@ -534,7 +534,7 @@
 						"style": "none",
 						"width": "0px"
 					},
-					"radius": "16px",
+					"radius": "var(--wp--preset--spacing--20)",
 					"right": {
 						"style": "none",
 						"width": "0px"


### PR DESCRIPTION
**Description**
A follow-up to https://github.com/WordPress/twentytwentyfour/pull/235, adjusting the preset and using it in place of the hard-coded 16px values for core/post-featured-image and core/quote. Notice the radius adjusts on mobile. 

![CleanShot 2023-09-06 at 16 20 13](https://github.com/WordPress/twentytwentyfour/assets/1813435/cccb1385-71c5-4ffa-8963-7024d7235f1e)
![CleanShot 2023-09-06 at 16 20 06](https://github.com/WordPress/twentytwentyfour/assets/1813435/44057aca-fe61-4098-b0e2-1e7ac0bea490)
