### PR TITLE
Templates: single template cleanup

### DIFF
--- a/patterns/comments.php
+++ b/patterns/comments.php
@@ -41,9 +41,8 @@
 		<!-- /wp:group -->
 	<!-- /wp:comment-template -->
 
-	<!-- wp:comments-pagination -->
+	<!-- wp:comments-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
 		<!-- wp:comments-pagination-previous /-->
-		<!-- wp:comments-pagination-numbers /-->
 		<!-- wp:comments-pagination-next /-->
 	<!-- /wp:comments-pagination -->
 

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,12 +1,12 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"6vh","bottom":"6vh"}}},"layout":{"type":"default"}} -->
-<div class="wp-block-group" style="padding-top:6vh;padding-bottom:6vh"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:post-featured-image /--></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"1em","padding":{"top":"2vh","bottom":"2vh"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-<div class="wp-block-group" style="padding-top:2vh;padding-bottom:2vh"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10","padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)"><!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:post-title {"fontSize":"x-large"} /--></div>
 <!-- /wp:group -->
 
@@ -14,61 +14,29 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"tagName":"main","lock":{"move":false,"remove":false},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group"><!-- wp:post-content {"lock":{"move":false,"remove":true},"layout":{"type":"constrained"}} /-->
+<main class="wp-block-group"><!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
 
 <!-- wp:post-terms {"term":"post_tag","separator":"  "} /--></main>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:spacer {"height":"4rem"} -->
-<div style="height:4rem" aria-hidden="true" class="wp-block-spacer"></div>
+<div class="wp-block-group"><!-- wp:spacer {"height":"var:preset|spacing|40"} -->
+<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:comments {"className":"wp-block-comments-query-loop"} -->
-<div class="wp-block-comments wp-block-comments-query-loop"><!-- wp:comments-title {"level":3} /-->
+<!-- wp:pattern {"slug":"twentytwentyfour/comments"} /-->
 
-<!-- wp:comment-template -->
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
-<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:group {"style":{"spacing":{"blockGap":"0.5em"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:avatar {"size":40,"style":{"spacing":{"margin":{"top":"0.5em"}}}} /-->
-
-<!-- wp:group {"style":{"spacing":{"blockGap":"0.2em"}}} -->
-<div class="wp-block-group"><!-- wp:comment-author-name /-->
-
-<!-- wp:comment-date {"format":"M j, Y","isLink":false} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
-<!-- wp:comment-content /-->
-
-<!-- wp:group {"style":{"spacing":{"blockGap":"0.5em"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:comment-edit-link /-->
-
-<!-- wp:comment-reply-link /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-<!-- /wp:comment-template -->
-
-<!-- wp:comments-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
-<!-- wp:comments-pagination-previous /-->
-
-<!-- wp:comments-pagination-numbers /-->
-
-<!-- wp:comments-pagination-next /-->
-<!-- /wp:comments-pagination -->
-
-<!-- wp:post-comments-form /-->
-
-<!-- wp:spacer {"height":"4rem"} -->
-<div style="height:4rem" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var:preset|spacing|40"} -->
+<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"bottom":"0vh"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group" style="padding-bottom:0vh"><!-- wp:post-navigation-link {"type":"previous","arrow":"arrow"} /-->
+<div class="wp-block-group" style="padding-bottom:0vh">
+	<!-- wp:post-navigation-link {"type":"previous","arrow":"arrow"} /-->
+	<!-- wp:post-navigation-link {"label":"Next","arrow":"arrow"} /--></div>
+<!-- /wp:group -->
 
-<!-- wp:post-navigation-link {"label":"Next","arrow":"arrow"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:comments --></div>
+</div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,9 +1,9 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:post-featured-image /--></div>
-<!-- /wp:group -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50)">
+
+<!-- wp:post-featured-image /-->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10","padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)"><!-- wp:group {"layout":{"type":"constrained"}} -->
@@ -12,13 +12,21 @@
 
 <!-- wp:template-part {"slug":"post-meta"} /--></div>
 <!-- /wp:group -->
-
-<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":false},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group"><!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
-
-<!-- wp:post-terms {"term":"post_tag","separator":"  "} /--></main>
+</div>
 <!-- /wp:group -->
 
+<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":false},"align":"full","layout":{"type":"default"}} -->
+<main class="wp-block-group alignfull">
+
+<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)">
+
+<!-- wp:post-terms {"term":"post_tag","separator":"  "} /-->
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:spacer {"height":"var:preset|spacing|40"} -->
 <div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>


### PR DESCRIPTION
**Description**

This PR cleans up the single post template. It rearranges the wrapper group blocks to allow for full and wide aligned content in the post content block, while maintaining horizontal padding on mobile (this was tricky!). Removes the comment markup to make use of the pattern and uses spacing presets over hardcoded units.

Partially addresses https://github.com/WordPress/twentytwentyfour/issues/224