### PR TITLE
Add fluid type scale

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -363,7 +363,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "0.75rem",
+					"fontSize": "var(--wp--preset--font-size--small)",
 					"fontStyle": "normal",
 					"fontWeight": "600"
 				}
@@ -380,7 +380,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "0.75rem"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/comment-edit-link": {
@@ -392,7 +392,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "0.75rem"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/comment-reply-link": {
@@ -404,27 +404,27 @@
 					}
 				},
 				"typography": {
-					"fontSize": "0.75rem"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/comments-pagination": {
 				"typography": {
-					"fontSize": "0.75rem"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/comments-pagination-next": {
 				"typography": {
-					"fontSize": "0.75rem"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/comments-pagination-numbers": {
 				"typography": {
-					"fontSize": "0.75rem"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/comments-pagination-previous": {
 				"typography": {
-					"fontSize": "0.75rem"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/gallery": {
@@ -469,7 +469,7 @@
 			},
 			"core/post-author": {
 				"typography": {
-					"fontSize": "0.8rem"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/post-author-name": {
@@ -486,7 +486,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "0.8rem"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/post-date": {
@@ -509,7 +509,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "0.8rem"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/post-excerpt": {
@@ -536,7 +536,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "0.8rem"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/post-title": {

--- a/theme.json
+++ b/theme.json
@@ -254,40 +254,43 @@
 			],
 			"fontSizes": [
 				{
-					"fluid": {
-						"max": "1.0625rem",
-						"min": "0.825rem"
-					},
+					"fluid": false,
 					"name": "Small",
-					"size": "1rem",
+					"size": "0.9rem",
 					"slug": "small"
 				},
 				{
-					"fluid": {
-						"max": "1.25rem",
-						"min": "1rem"
-					},
+					"fluid": false,
 					"name": "Medium",
-					"size": "1.125rem",
+					"size": "1.05rem",
 					"slug": "medium"
 				},
 				{
 					"fluid": {
-						"max": "2rem",
-						"min": "1.75rem"
+						"min": "1.39rem",
+						"max": "1.85rem"
 					},
 					"name": "Large",
-					"size": "1.75rem",
+					"size": "1.85rem",
 					"slug": "large"
 				},
 				{
 					"fluid": {
-						"max": "3rem",
-						"min": "2.5rem"
+						"min": "1.85rem",
+						"max": "2.46rem"
 					},
 					"name": "Extra Large",
-					"size": "3rem",
+					"size": "2.46rem",
 					"slug": "x-large"
+				},
+				{
+					"fluid": {
+						"min": "2.46rem",
+						"max": "3.27rem"
+					},
+					"name": "Extra Extra Large",
+					"size": "3.27rem",
+					"slug": "xx-large"
 				}
 			]
 		},
@@ -301,26 +304,6 @@
 				}
 			},
 			"core/button": {
-				"color": {
-					"background": "var(--wp--preset--color--contrast)",
-					"text": "var(--wp--preset--color--base)"
-				},
-				"border": {
-					"radius": "6px"
-				},
-				"spacing": {
-					"padding": {
-						"bottom": "0.6rem",
-						"left": "1rem",
-						"right": "1rem",
-						"top": "0.6rem"
-					}
-				},
-				"typography": {
-					"fontSize": "0.9rem",
-					"fontStyle": "normal",
-					"fontWeight": "500"
-				},
 				"variations": {
 					"outline": {
 						"border": {
@@ -347,9 +330,6 @@
 			"core/buttons": {
 				"spacing": {
 					"blockGap": "0.7rem"
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/code": {
@@ -484,16 +464,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"fontStyle": "normal",
 					"fontWeight": "500"
-				}
-			},
-			"core/paragraph": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"letterSpacing": "0.01em",
-					"lineHeight": "1.5"
 				}
 			},
 			"core/post-author": {
@@ -620,7 +591,7 @@
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--cardo)",
-					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontSize": "var(--wp--preset--font-size--x-large)",
 					"fontStyle": "italic",
 					"fontWeight": "400",
 					"letterSpacing": "0em",
@@ -644,7 +615,7 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontSize": "var(--wp--preset--font-size--large)",
 					"lineHeight": "1.6"
 				}
 			},
@@ -715,11 +686,24 @@
 					}
 				},
 				"border": {
-					"radius": "0.25rem"
+					"radius": ".33rem"
 				},
 				"color": {
 					"background": "var(--wp--preset--color--contrast)",
 					"text": "var(--wp--preset--color--base)"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "0.6rem",
+						"left": "1rem",
+						"right": "1rem",
+						"top": "0.6rem"
+					}
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontStyle": "normal",
+					"fontWeight": "500"
 				}
 			},
 			"caption": {
@@ -733,12 +717,13 @@
 			},
 			"h1": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--x-large)"
+					"fontSize": "var(--wp--preset--font-size--xx-large)",
+					"lineHeight": "1.15"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontSize": "2.37rem"
+					"fontSize": "var(--wp--preset--font-size--x-large)"
 				}
 			},
 			"h3": {
@@ -748,17 +733,17 @@
 			},
 			"h4": {
 				"typography": {
-					"fontSize": "1.5rem"
+					"fontSize": "var(--wp--preset--font-size--medium)"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontSize": "1.25rem"
+					"fontSize": "var(--wp--preset--font-size--medium)"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontSize": "1.12rem"
+					"fontSize": "var(--wp--preset--font-size--medium)"
 				}
 			},
 			"heading": {
@@ -793,10 +778,10 @@
 		},
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--system-font)",
-			"fontSize": "var(--wp--preset--font-size--small)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
 			"fontStyle": "normal",
 			"fontWeight": "400",
-			"lineHeight": "1.6"
+			"lineHeight": "1.55"
 		}
 	},
 	"templateParts": [


### PR DESCRIPTION
**Description**

An alternate (and inspired by) to https://github.com/WordPress/twentytwentyfour/pull/263. This only changes the theme.json; not patterns, as we'll have conflicts doing both together while patterns are changing yet. 

Key points: 
- Uses a 1.333 ratio, starting at 1.05rem (effectively 17px) as a body font size. 
- The "medium" font size is used as the body/default font size. 
- Headings now use font size presets. 
- Small and Medium font sizes are not fluid (to ensure readability on mobile). 
- Large, XL, and XXL font sizes scale down one type-scale size lower on mobile. 

Others: 
- Updated button to use the type scale (and removed duplicate button styling). 


### Visuals
Desktop: 
<img width="724" alt="CleanShot 2023-09-07 at 11 28 06" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/238d8c66-e8e7-459f-aaaf-f2e56e95a401">

Mobile: 
<img width="413" alt="CleanShot 2023-09-07 at 11 29 59" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/f6ba0c5d-0418-4d88-adaf-3284fc97ea8d">

### Patterns
We do need to follow-up with changes to a few patterns; but generally they flow pretty well. Here's a few shots of patterns that don't need changes: 

<img width="1489" alt="CleanShot 2023-09-07 at 11 33 02" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/d0f92374-08d9-430f-92c9-f15b88e9b407">
<img width="1594" alt="CleanShot 2023-09-07 at 11 33 58" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/9eb7f5bb-319e-4307-82e6-52be4cca277a">
<img width="1310" alt="CleanShot 2023-09-07 at 11 35 44" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/aab336bd-5a6b-4f83-bd0e-264376bb39aa">
<img width="1591" alt="CleanShot 2023-09-07 at 11 33 50" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/b2e3c5ff-7c5d-4503-8412-2e2cf9d111e9">
<img width="1434" alt="CleanShot 2023-09-07 at 11 36 15" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/03afaa0f-f597-4f22-90c0-364e6262b569">
