### PR TITLE
Add back core/post-title margin bottom

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -580,11 +580,6 @@
 							"textDecoration": "none"
 						}
 					}
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "0"
-					}
 				}
 			},
 			"core/pullquote": {


### PR DESCRIPTION
**Description**

Closes #225 by removing the spacing.margin.bottom 0 applied to the post title block in theme.json. 

<img width="850" alt="CleanShot 2023-09-07 at 14 33 21" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/63701677-8592-48a0-a206-67135d4a89a3">
