### PR TITLE
Adjust default page and no title templates

### DIFF
--- a/templates/page-no-title.html
+++ b/templates/page-no-title.html
@@ -1,9 +1,9 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"default"}} -->
-<div class="wp-block-group">
-<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":false},"style":{"spacing":{"padding":{"top":"10vh","bottom":"8vh"}}}} -->
-<main class="wp-block-group" style="padding-top:10vh;padding-bottom:8vh"><!-- wp:post-content {"lock":{"move":false,"remove":true},"layout":{"type":"constrained"}} /--></main>
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0"}}}} -->
+<main class="wp-block-group" style="margin-top:0">
+	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+</main>
 <!-- /wp:group -->
-</div>
-<!-- /wp:group -->
+
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,20 +1,19 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0"}}}} -->
-<main class="wp-block-group" style="margin-top:0"><!-- wp:group {"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group">
-
-		<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group"><!-- wp:group {"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group"><!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+		<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
 
 		<!-- wp:post-title {"textAlign":"center","level":1} /-->
 
-		<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
-			<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- wp:spacer {"height":"var:preset|spacing|30","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+		<div style="margin-top:0;margin-bottom:0;height:var(--wp--preset--spacing--30)" aria-hidden="true"
+			class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
 
-		<!-- wp:post-featured-image {"overlayColor":"contrast","dimRatio":50} /-->
+		<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,12 +1,24 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":false},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"default"}} -->
-<main class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0"}}}} -->
+<main class="wp-block-group" style="margin-top:0"><!-- wp:group {"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group">
 
-	<!-- wp:post-featured-image /-->
+		<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
 
-	<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
-	
+		<!-- wp:post-title {"textAlign":"center","level":1} /-->
+
+		<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
+			<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
+
+		<!-- wp:post-featured-image {"overlayColor":"contrast","dimRatio":50} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
Adjusting the templates and spacing to ensure they look and work nicely. Related to #224.

### Page template, without featured image: 

<img width="1531" alt="CleanShot 2023-09-07 at 15 17 12" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/3079398e-e8a4-41bb-831a-d4eeb520ea8f">

<img width="572" alt="CleanShot 2023-09-07 at 15 16 59" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/64ce180d-ac99-430e-946f-968ae618abc6">

### Page template, with featured image: 
<img width="1532" alt="CleanShot 2023-09-07 at 15 17 28" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/6bcae9e5-c19e-4944-8d97-e4ac15d123a0">
<img width="571" alt="CleanShot 2023-09-07 at 15 17 59" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/e30fc948-bc9d-41e7-bdec-27b681843e08">

### Page with no title: 

<img width="1495" alt="CleanShot 2023-09-07 at 15 22 07" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/5765f62a-4142-40fd-ad94-15d946b649ee">
