### PR TITLE
Use presets for outer spacing

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -785,10 +785,8 @@
 		"spacing": {
 			"blockGap": "1.2rem",
 			"padding": {
-				"bottom": "0",
 				"left": "var(--wp--preset--spacing--50)",
-				"right": "var(--wp--preset--spacing--50)",
-				"top": "0"
+				"right": "var(--wp--preset--spacing--50)"
 			}
 		},
 		"typography": {

--- a/theme.json
+++ b/theme.json
@@ -785,10 +785,10 @@
 		"spacing": {
 			"blockGap": "1.2rem",
 			"padding": {
-				"bottom": "0vh",
-				"left": "6vw",
-				"right": "6vw",
-				"top": "0vh"
+				"bottom": "0",
+				"left": "var(--wp--preset--spacing--50)",
+				"right": "var(--wp--preset--spacing--50)",
+				"top": "0"
 			}
 		},
 		"typography": {


### PR DESCRIPTION
Uses the spacing presets for outer spacing; making it fit a bit better for mobile + matching the spacing used in patterns. 

Closes #224. 

### Visual: 

<img width="495" alt="CleanShot 2023-09-07 at 15 53 26" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/d09986d3-af04-4253-851c-e3e81cc46840">
