### PR TITLE
Organize starter page patterns

### DIFF
--- a/patterns/page-01-business-home.php
+++ b/patterns/page-01-business-home.php
@@ -1,9 +1,12 @@
 <?php
 /**
- * Title: home
+ * Title: Home
  * Slug: twentytwentyfour/home
  * Categories: about
+ * Keywords: page, starter
  * Block Types: core/post-content
+ * Post Types: page
+ * Viewport width: 1400
  * Template Types: home
  */
 ?>

--- a/patterns/page-02-business-about.php
+++ b/patterns/page-02-business-about.php
@@ -1,10 +1,12 @@
 <?php
 /**
- * Title: Business About
+ * Title: About
  * Slug: twentytwentyfour/business-about
  * Categories: about
+ * Keywords: page, starter
  * Block Types: core/post-content
  * Post Types: page
+ * Viewport width: 1400
  */
 ?>
 

--- a/patterns/page-03-portfolio-overview.php
+++ b/patterns/page-03-portfolio-overview.php
@@ -1,11 +1,12 @@
 <?php
 /**
- * Title: Project Overview
+ * Title: Portfolio Overview
  * Slug: twentytwentyfour/page-project-overview
  * Categories: about
  * Keywords: page, starter
  * Block Types: core/post-content
  * Post Types: page
+ * Viewport width: 1400
  */
 ?>
 

--- a/patterns/page-04-newsletter-landing.php
+++ b/patterns/page-04-newsletter-landing.php
@@ -1,8 +1,9 @@
 <?php
 /**
- * Title: Newsletter Subscribe
- * Slug: twentytwentyfour/page-newsletter-subscribe
+ * Title: Newsletter Landing
+ * Slug: twentytwentyfour/page-newsletter-landing
  * Categories: call-to-action
+ * Keywords: page, starter
  * Block Types: core/post-content
  * Post Types: page
  * Viewport width: 1100


### PR DESCRIPTION
**Description**

Organizes the page patterns to look nicely together, adds `page` and `starter` keywords to help find starter patterns, and sets viewport width for each. 

**Screenshots**

Before: 

<img width="1437" alt="CleanShot 2023-09-07 at 16 58 42" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/fe0b13fe-73fa-4414-bc7d-abe962d63eb4">


After: 

<img width="1438" alt="CleanShot 2023-09-07 at 16 57 57" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/9a09ea54-d4a5-4057-82a1-1bfe38c27254">

