### PR TITLE
Add Quote block global styling

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -597,17 +597,55 @@
 			},
 			"core/quote": {
 				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"style": "solid",
-					"width": "0 0 0 1px"
+					"radius": "var(--wp--preset--spacing--20)"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--base-2)"
+				},
+				"css": "&:not(.is-style-plain) :where(p) {font-size:var(--wp--preset--font-size--large);} &.is-style-plain :where(cite) {font-size:var(--wp--preset--font-size--small);} &.is-style-plain :where(p) {font-size:var(--wp--preset--font-size--medium);} :where(p) {margin-block:0;}",
+				"elements": {
+					"cite": {
+						"typography": {
+							"fontFamily": "var(--wp--preset--font-family--system-font)",
+							"fontSize": "var(--wp--preset--font-size--medium)",
+							"fontStyle": "normal",
+							"lineHeight": "1"
+						}
+					}
 				},
 				"spacing": {
 					"padding": {
-						"left": "var(--wp--preset--spacing--50)"
+						"bottom": "var(--wp--preset--spacing--30)",
+						"left": "var(--wp--preset--spacing--30)",
+						"right": "var(--wp--preset--spacing--30)",
+						"top": "var(--wp--preset--spacing--30)"
 					}
 				},
 				"typography": {
-					"fontStyle": "normal"
+					"fontFamily": "var(--wp--preset--font-family--cardo)",
+					"fontSize": "var(--wp--preset--font-size--x-large)",
+					"fontStyle": "italic"
+				},
+				"variations": {
+					"plain": {
+						"border": {
+							"color": "var(--wp--preset--color--primary)",
+							"radius": "0",
+							"style": "solid",
+							"width": "0 0 0 2px"
+						},
+						"color": {
+							"background": "transparent"
+						},
+						"spacing": {
+							"padding": {
+								"bottom": "var(--wp--preset--spacing--10)",
+								"left": "var(--wp--preset--spacing--30)",
+								"right": "var(--wp--preset--spacing--30)",
+								"top": "var(--wp--preset--spacing--10)"
+							}
+						}
+					}
 				}
 			},
 			"core/search": {

--- a/theme.json
+++ b/theme.json
@@ -602,7 +602,7 @@
 				"color": {
 					"background": "var(--wp--preset--color--base-2)"
 				},
-				"css": "&:not(.is-style-plain) :where(p) {font-size:var(--wp--preset--font-size--large);} &.is-style-plain :where(cite) {font-size:var(--wp--preset--font-size--small);} &.is-style-plain :where(p) {font-size:var(--wp--preset--font-size--medium);} :where(p) {margin-block:0;}",
+				"css": "& :where(p) {margin-block-start:0;margin-block-end:var(--wp--preset--spacing--10);} &.is-style-plain :where(cite) {font-size:var(--wp--preset--font-size--small);}",
 				"elements": {
 					"cite": {
 						"typography": {
@@ -623,7 +623,7 @@
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--cardo)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
+					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontStyle": "italic"
 				},
 				"variations": {
@@ -644,6 +644,9 @@
 								"right": "var(--wp--preset--spacing--30)",
 								"top": "var(--wp--preset--spacing--10)"
 							}
+						},
+						"typography": {
+							"fontSize": "var(--wp--preset--font-size--medium)"
 						}
 					}
 				}

--- a/theme.json
+++ b/theme.json
@@ -629,7 +629,7 @@
 				"variations": {
 					"plain": {
 						"border": {
-							"color": "var(--wp--preset--color--primary)",
+							"color": "var(--wp--preset--color--contrast)",
 							"radius": "0",
 							"style": "solid",
 							"width": "0 0 0 2px"

--- a/theme.json
+++ b/theme.json
@@ -602,29 +602,29 @@
 				"color": {
 					"background": "var(--wp--preset--color--base-2)"
 				},
-				"css": "& :where(p) {margin-block-start:0;margin-block-end:var(--wp--preset--spacing--10);} &.is-style-plain :where(cite) {font-size:var(--wp--preset--font-size--small);}",
+				"css": "& :where(p) {margin-block-start:0;margin-block-end:calc(var(--wp--preset--spacing--10) + 0.5rem);}",
 				"elements": {
 					"cite": {
 						"typography": {
 							"fontFamily": "var(--wp--preset--font-family--system-font)",
-							"fontSize": "var(--wp--preset--font-size--medium)",
-							"fontStyle": "normal",
-							"lineHeight": "1"
+							"fontSize": "var(--wp--preset--font-size--small)",
+							"fontStyle": "normal"
 						}
 					}
 				},
 				"spacing": {
 					"padding": {
-						"bottom": "var(--wp--preset--spacing--30)",
-						"left": "var(--wp--preset--spacing--30)",
-						"right": "var(--wp--preset--spacing--30)",
-						"top": "var(--wp--preset--spacing--30)"
+						"bottom": "calc(var(--wp--preset--spacing--30) + 0.75rem)",
+						"left": "calc(var(--wp--preset--spacing--30) + 0.75rem)",
+						"right": "calc(var(--wp--preset--spacing--30) + 0.75rem)",
+						"top": "calc(var(--wp--preset--spacing--30) + 0.75rem)"
 					}
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--cardo)",
 					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontStyle": "italic"
+					"fontStyle": "italic",
+					"lineHeight": "1.3"
 				},
 				"variations": {
 					"plain": {
@@ -639,10 +639,10 @@
 						},
 						"spacing": {
 							"padding": {
-								"bottom": "var(--wp--preset--spacing--10)",
-								"left": "var(--wp--preset--spacing--30)",
-								"right": "var(--wp--preset--spacing--30)",
-								"top": "var(--wp--preset--spacing--10)"
+								"bottom": "var(--wp--preset--spacing--20)",
+								"left": "calc(var(--wp--preset--spacing--20) + 0.5rem)",
+								"right": "0",
+								"top": "var(--wp--preset--spacing--20)"
 							}
 						},
 						"typography": {


### PR DESCRIPTION
**Description**

Addresses #257 

**Screenshots**

![Screenshot 2023-09-08 at 10 33 57 AM](https://github.com/WordPress/twentytwentyfour/assets/405912/063048b4-60cc-49c2-8a1b-e7b1e3699582)

~~Note: I have to do a `"css"` entry to try and override the default `core/paragraph` font-size styling. However, it might be recommended to remove the `fontSize` on `core/paragraph`. This should just inherit the `body` `font-size`.~~ 🤔 
~~Note: this required the removal of the existing Paragraph block `"core/paragraph"` font styling, which should mostly be inherited from the `body` elements typography entry.~~