### PR TITLE
#33 Making buttons descriptive, consistent case

### DIFF
--- a/patterns/about-2.php
+++ b/patterns/about-2.php
@@ -27,7 +27,7 @@
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Learn More', 'Call to Action button text', 'twentytwentyfour' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'About us', 'Call to Action button text', 'twentytwentyfour' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group --></div>

--- a/patterns/hero.php
+++ b/patterns/hero.php
@@ -26,7 +26,7 @@
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Learn More', 'Button\'s label of the hero section', 'twentytwentyfour' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'About us', 'Button\'s label of the hero section', 'twentytwentyfour' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->
 

--- a/patterns/left-aligned-cta-image.php
+++ b/patterns/left-aligned-cta-image.php
@@ -28,12 +28,12 @@
 <!-- /wp:list -->
 
 <!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-outline"} -->
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Learn More', 'sample content for call to action button', 'twentytwentyfour' ); ?></a></div>
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Download app', 'sample content for call to action button', 'twentytwentyfour' ); ?></a></div>
 <!-- /wp:button -->
 
-<!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Get Started', 'sample content for call to action button', 'twentytwentyfour' ); ?></a></div>
+<!-- wp:button {"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'How it works', 'sample content for call to action button', 'twentytwentyfour' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:column -->

--- a/patterns/page-04-newsletter-landing.php
+++ b/patterns/page-04-newsletter-landing.php
@@ -30,7 +30,7 @@
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Sign Up', 'sample content for newsletter subscription button', 'twentytwentyfour' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Sign up', 'sample content for newsletter subscription button', 'twentytwentyfour' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover -->

--- a/patterns/services-cta.php
+++ b/patterns/services-cta.php
@@ -26,7 +26,7 @@
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Learn More', 'Call to Action Button Text', 'twentytwentyfour' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Our services', 'Call to Action Button Text', 'twentytwentyfour' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:column --></div>


### PR DESCRIPTION
**Description**

As described in #33 the button text used in the theme is ambiguous and not recommended for accessibility i.e. "Learn More". This PR changes the text to be descriptive and contextual to the pattern it is used in and also changes the case of button text to be sentence case, where only the first letter of the first word is capitalized. This is generally considered more readable than title case.

Submitted as part of WordCamp Malaysia Contributor Day.

**Screenshots**

Previous:

<img width="1267" alt="Screenshot-2023-09-08 --11 52 20@2x" src="https://github.com/WordPress/twentytwentyfour/assets/10615884/229792bb-c919-4e2c-80ae-126e0f71955e">

Proposed:

<img width="1264" alt="Screenshot-2023-09-08 --11 52 36@2x" src="https://github.com/WordPress/twentytwentyfour/assets/10615884/21816fb9-ec3d-470d-a850-1933c839fae5">

**Testing Instructions**

1. Activate theme
2. Test the following patterns:

- About 2
- Hero
- Left Aligned CTA image
- Page Newsletter subscribe
- Services CTA

**Contributors**

@thetwopct (myself) (username: bonkerz on wp.org)
