### PR TITLE
Add clarification for development mode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ If you'd like to help with triage, let @luminuu and @MaggieCabrera know in [Word
 2. Clone / download this repository into your `/wp-content/themes/` directory.
 3. Install and activate the [Gutenberg plugin](https://wordpress.org/plugins/gutenberg/).
 
+Also, consider enabling [development mode](https://make.wordpress.org/core/2023/07/14/configuring-development-mode-in-6-3/) with `define( ‘WP_DEVELOPMENT_MODE’, ‘theme’ );` in your `wp-config.php`. This will help minimize caching of `theme.json` while you're developing.
+
 ### Design
 
 The theme is designed in [Figma](https://www.figma.com/file/AlYr03vh4dVimwYwQkTdf6/Twenty-Twenty-Four?type=design&t=C79166eDp3vX7OOD-6). You can contribute by designing one of the [patterns](https://github.com/WordPress/twentytwentyfour/issues?q=is%3Aissue+is%3Aopen+label%3A%22%5BComponent%5D+Block+Patterns%22) planned for Twenty Twenty-Four. 


### PR DESCRIPTION
**Description**

As I mentioned in [the last #core-themes meeting](https://make.wordpress.org/core/2023/09/06/default-theme-chat-summary-august-30th-2023-2/). It is advisable to configure development mode when working on the theme, which minimizes `theme.json` caching.

Citing the original announcement post on Make - [Configuring development mode in 6.3](https://make.wordpress.org/core/2023/07/14/configuring-development-mode-in-6-3/):

> However, if you are actively developing a theme on the site and modifying `theme.json` constantly, having to manually invalidate the cache all the time would be detrimental to the development workflow. Therefore, that specific caching functionality is bypassed if the development mode is set to “theme”.
