### PR TITLE
Updating required WordPress version to 6.4

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Twenty Twenty-Four ===
 Contributors: wordpressdotorg
-Requires at least: 6.0
+Requires at least: 6.4
 Tested up to: 6.4
 Requires PHP: 7.0
 License: GPLv2 or later


### PR DESCRIPTION
**Description**

This is for the issue of: https://github.com/WordPress/twentytwentyfour/issues/197

**Screenshots**

N/A

**Testing Instructions**

N/A

**Contributors**

rajinsharwar
