### PR TITLE
Make single-X templates available for posts

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -872,14 +872,14 @@
 		{
 			"name": "single-writer",
 			"postTypes": [
-				"page"
+				"post"
 			],
 			"title": "Single Writer"
 		},
 		{
 			"name": "single-with-sidebar",
 			"postTypes": [
-				"page"
+				"post"
 			],
 			"title": "Single with Sidebar"
 		}


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->
Single-writer and single-with-sidebar were available for pages, not for posts.
These templates include the post meta template part and are intended for posts.

(Pages already have page-writer)

**Testing Instructions**

Create a new post. Confirm that the two templates can be selected from "templates" option in the the post sidebar.
