### PR TITLE
Fix PHP issue in the sidebar template part

### DIFF
--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -34,7 +34,7 @@
 <div class="wp-block-group"><!-- wp:post-title {"isLink":true,"fontSize":"medium"} /-->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"0.22em"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y", {"isLink":true}} /-->
+<div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y","isLink":true} /-->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"},"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
 <p class="has-base-2-color has-text-color has-link-color" style="font-size:0.8rem"><?php echo esc_html__( '—', 'twentytwentyfour' ); ?></p>


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->
There is a problem with the code for the post date block in the Latest Posts section of the sidebar template part.
This prevents the single with sidebar template from displaying on the front.

The PR solves the typo in the markup.

**Testing Instructions**

Create a new post. 
Assign it the "Single with sidebar" template.
Save and view the post on the front.
