### PR TITLE
Updates to Single Post spacing and styling

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -73,6 +73,13 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				'label' => __( 'Arrow icon', 'twentytwentyfour' ),
 			)
 		);
+		register_block_style(
+			'core/post-terms',
+			array(
+				'name'  => 'solid',
+				'label' => __( 'Solid', 'twentytwentyfour' ),
+			)
+		);
 	}
 endif;
 

--- a/functions.php
+++ b/functions.php
@@ -76,8 +76,8 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 		register_block_style(
 			'core/post-terms',
 			array(
-				'name'  => 'solid',
-				'label' => __( 'Solid', 'twentytwentyfour' ),
+				'name'  => 'pill',
+				'label' => __( 'Pill', 'twentytwentyfour' ),
 			)
 		);
 	}

--- a/style.css
+++ b/style.css
@@ -52,3 +52,20 @@ a {
 .is-style-arrow-icon-details[open] > summary {
 	list-style-type: '\2192\00a0\00a0\00a0';
 }
+
+/*
+ * Styles for the taxonomy/tags on single posts
+ * https://github.com/WordPress/twentytwentyfour/issues/XX
+ */
+
+.wp-block-post-terms a {
+	display:inline-block;
+	background-color: #f2f2f2;
+	padding: 6px 14px;
+	border-radius:16px;
+	margin: 0 10px 10px 0;
+}
+
+.wp-block-post-terms a:hover {
+	background:#eee;
+}

--- a/style.css
+++ b/style.css
@@ -55,12 +55,11 @@ a {
 
 /*
  * Styles variation for post terms
- * https://github.com/WordPress/twentytwentyfour/issues/319
+ * https://github.com/WordPress/gutenberg/issues/24956
  */
 
-.is-style-solid a,
-.is-style-solid span:not(.block-editor-rich-text__editable,.wp-block-post-terms__separator),
-.is-style-solid span:not(.block-editor-rich-text__editable) span
+.is-style-pill a,
+.is-style-pill span:not([class], [data-rich-text-placeholder])
 {
 	display:inline-block;
 	background-color: #f2f2f2;
@@ -69,6 +68,6 @@ a {
 	margin: 0 10px 10px 0;
 }
 
-.is-style-solid a:hover {
+.is-style-pill a:hover {
 	background:#eee;
 }

--- a/style.css
+++ b/style.css
@@ -59,8 +59,9 @@ a {
  */
 
 .is-style-solid a,
-.is-style-solid span:not(.block-editor-rich-text__editable) span,
-.is-style-solid span:not(.block-editor-rich-text__editable,.wp-block-post-terms__separator){
+.is-style-solid span:not(.block-editor-rich-text__editable,.wp-block-post-terms__separator),
+.is-style-solid span:not(.block-editor-rich-text__editable) span
+{
 	display:inline-block;
 	background-color: #f2f2f2;
 	padding: 6px 14px;

--- a/style.css
+++ b/style.css
@@ -58,7 +58,7 @@ a {
  * https://github.com/WordPress/twentytwentyfour/issues/XX
  */
 
-.wp-block-post-terms a {
+.wp-block-post-terms.taxonomy-post_tag a {
 	display:inline-block;
 	background-color: #f2f2f2;
 	padding: 6px 14px;

--- a/style.css
+++ b/style.css
@@ -54,11 +54,13 @@ a {
 }
 
 /*
- * Styles for the taxonomy/tags on single posts
- * https://github.com/WordPress/twentytwentyfour/issues/XX
+ * Styles variation for post terms
+ * https://github.com/WordPress/twentytwentyfour/issues/319
  */
 
-.wp-block-post-terms.taxonomy-post_tag a {
+.is-style-solid a,
+.is-style-solid span:not(.block-editor-rich-text__editable) span,
+.is-style-solid span:not(.block-editor-rich-text__editable,.wp-block-post-terms__separator){
 	display:inline-block;
 	background-color: #f2f2f2;
 	padding: 6px 14px;
@@ -66,6 +68,6 @@ a {
 	margin: 0 10px 10px 0;
 }
 
-.wp-block-post-terms a:hover {
+.is-style-solid a:hover {
 	background:#eee;
 }

--- a/templates/single.html
+++ b/templates/single.html
@@ -12,11 +12,11 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":false},"align":"full","layout":{"type":"default"}} -->
-<main class="wp-block-group alignfull">
+<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":false},"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"default"}} -->
+<main class="wp-block-group alignfull" style="margin-bottom:var(--wp--preset--spacing--40)">
 
-<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
-
+	<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
+		
 </main>
 <!-- /wp:group -->
 

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,18 +1,15 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50)">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50"},"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--50)"><!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
 
-<!-- wp:post-featured-image /-->
-
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10","padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10","padding":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+<div class="wp-block-group" style="padding-top:0;padding-bottom:0"><!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:post-title {"level":1,"fontSize":"x-large"} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"post-meta"} /--></div>
-<!-- /wp:group -->
-</div>
+<!-- wp:template-part {"slug":"post-meta","theme":"twentytwentyfour"} /--></div>
+<!-- /wp:group --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"tagName":"main","lock":{"move":false,"remove":false},"align":"full","layout":{"type":"default"}} -->

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,6 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50"},"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
+<main class="wp-block-group alignfull"><!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50"},"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--50)"><!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10","padding":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
@@ -12,16 +13,17 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":false},"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"default"}} -->
-<main class="wp-block-group alignfull" style="margin-bottom:var(--wp--preset--spacing--40)">
+<!-- wp:group {"lock":{"move":false,"remove":false},"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull" style="margin-bottom:var(--wp--preset--spacing--40)">
 
 	<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
 		
-</main>
+</div>
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:post-terms {"term":"post_tag","separator":"  "} /-->
+<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)">
+	<!-- wp:post-terms {"term":"post_tag","separator":"  ","className":"is-style-solid"} /-->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:spacer {"height":"var:preset|spacing|40"} -->
@@ -42,10 +44,9 @@
 <div class="wp-block-group" style="padding-bottom:0vh">
 	<!-- wp:post-navigation-link {"type":"previous","arrow":"arrow"} /-->
 	<!-- wp:post-navigation-link {"label":"Next","arrow":"arrow"} /--></div>
-<!-- /wp:group -->
-
-</div>
 <!-- /wp:group --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -24,8 +24,8 @@
 <div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:post-terms {"term":"post_tag","separator":"  "} /-->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<div class="wp-block-group"><!-- wp:spacer {"height":"var:preset|spacing|40"} -->
+<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:separator {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"backgroundColor":"accent"} -->

--- a/templates/single.html
+++ b/templates/single.html
@@ -21,13 +21,16 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)">
+<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:post-terms {"term":"post_tag","separator":"  "} /-->
 
-<!-- wp:post-terms {"term":"post_tag","separator":"  "} /-->
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:spacer {"height":"var:preset|spacing|40"} -->
-<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
+<div class="wp-block-group"><!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
+
+<!-- wp:separator {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"backgroundColor":"accent"} -->
+<hr class="wp-block-separator has-text-color has-accent-color has-alpha-channel-opacity has-accent-background-color has-background" style="margin-bottom:var(--wp--preset--spacing--40)"/>
+<!-- /wp:separator -->
 
 <!-- wp:pattern {"slug":"twentytwentyfour/comments"} /-->
 

--- a/templates/single.html
+++ b/templates/single.html
@@ -23,7 +23,7 @@
 
 <!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)">
-	<!-- wp:post-terms {"term":"post_tag","separator":"  ","className":"is-style-solid"} /-->
+	<!-- wp:post-terms {"term":"post_tag","separator":"  ","className":"is-style-pill"} /-->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:spacer {"height":"var:preset|spacing|40"} -->


### PR DESCRIPTION
**Description**

Addressing #319 - this aims to update the single.html file to be closer to the [Figma design](https://www.figma.com/file/AlYr03vh4dVimwYwQkTdf6/Twenty-Twenty-Four?type=design&node-id=492-1457&mode=design&t=1ksmbRV1pC17uorE-0). Most notable additions.

* Update spacing between main elements (Title, Body, Comments).
* Add separator at bottom of post.
* Add CSS styling for the taxonomy/tags

**Screenshots**

![theme-building local_3-years-at-automattic_ (1)](https://github.com/WordPress/twentytwentyfour/assets/1842363/81368564-9f18-4302-889b-a9ecef1d0505)

** Questions **

I did my best to use theme presets where possible but there were a few aspects I needed to clarify..

* Comments title sizing was different - but uses the closest preset sizing to what we have.
* There's no preset colors with the subtlety used for the tags/taxonomy background - so I've hard-coded that into the CSS (which I imagine we need to amend).
* Similarly - the other values in the CSS for the tags didn't have matching presets
