### PR TITLE
Fix PHP issue in hidden-sidebar-writer.php

### DIFF
--- a/patterns/hidden-sidebar-writer.php
+++ b/patterns/hidden-sidebar-writer.php
@@ -34,7 +34,7 @@
 <div class="wp-block-group"><!-- wp:post-title {"isLink":true,"fontSize":"medium"} /-->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"0.22em"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y", {"isLink":true}} /-->
+<div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y", "isLink":true} /-->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"},"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
 <p class="has-base-2-color has-text-color has-link-color" style="font-size:0.8rem"><?php echo esc_html__( '—', 'twentytwentyfour' ); ?></p>


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->
This is the same fix as in https://github.com/WordPress/twentytwentyfour/pull/313 but for hidden-sidebar-writer.php.

**Testing Instructions**
Create a new page.
Assign it the "home writer" template.
Save and view the front.
Confirm that there is no fatal error and the content loads.
