### PR TITLE
Update comments area

### DIFF
--- a/patterns/hidden-comments.php
+++ b/patterns/hidden-comments.php
@@ -10,32 +10,22 @@
 <!-- wp:comments {"className":"wp-block-comments-query-loop"} -->
 <div class="wp-block-comments wp-block-comments-query-loop">
 	<!-- wp:comments-title {"level":3} /-->
-
 	<!-- wp:comment-template -->
-		<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
-		<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)">
+		<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+		<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--30)">
 			<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.5em"}}} -->
 			<div class="wp-block-group">
 				<!-- wp:avatar {"size":40,"style":{"spacing":{"margin":{"top":"0.5em"}}}} /-->
-
 				<!-- wp:group -->
 				<div class="wp-block-group">
 					<!-- wp:comment-author-name /-->
-
-					<!-- wp:group {"layout":{"type":"flex"},"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"},"blockGap":"0.5em"}}} -->
-					<div class="wp-block-group" style="margin-top:0px;margin-bottom:0px">
-						<!-- wp:comment-date {"format":"F j, Y \\a\\t g:i a"} /-->
-
-						<!-- wp:comment-edit-link /-->
-					</div>
-					<!-- /wp:group -->
+					<!-- wp:comment-date {"format":"F j, Y \\a\\t g:i a"} /-->
 				</div>
 				<!-- /wp:group -->
 			</div>
 			<!-- /wp:group -->
-
 			<!-- wp:comment-content /-->
-
+			<!-- wp:comment-edit-link /-->
 			<!-- wp:comment-reply-link /-->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/hidden-comments.php
+++ b/patterns/hidden-comments.php
@@ -25,8 +25,12 @@
 			</div>
 			<!-- /wp:group -->
 			<!-- wp:comment-content /-->
-			<!-- wp:comment-edit-link /-->
-			<!-- wp:comment-reply-link /-->
+			<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+			<div class="wp-block-group">
+				<!-- wp:comment-edit-link /-->
+				<!-- wp:comment-reply-link /-->
+			</div>
+			<!-- /wp:group -->
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:comment-template -->

--- a/theme.json
+++ b/theme.json
@@ -478,9 +478,6 @@
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
-			"core/comment-template": {
-				"css": "& li ol {border-left: 1px solid var(--wp--preset--color--contrast)}"
-			},
 			"core/gallery": {
 				"spacing": {
 					"margin": {

--- a/theme.json
+++ b/theme.json
@@ -419,7 +419,6 @@
 				}
 			},
 			"core/comment-edit-link": {
-				"css": "display: inline",
 				"elements": {
 					"link": {
 						"color": {
@@ -440,7 +439,6 @@
 				}
 			},
 			"core/comment-reply-link": {
-				"css": "display: inline",
 				"elements": {
 					"link": {
 						"color": {

--- a/theme.json
+++ b/theme.json
@@ -302,7 +302,7 @@
 		"blocks": {
 			"core/avatar": {
 				"border": {
-					"radius": "100px"
+					"radius": "90px"
 				}
 			},
 			"core/button": {
@@ -361,6 +361,14 @@
 					"link": {
 						"color": {
 							"text": "var(--wp--preset--color--contrast)"
+						},
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
 						}
 					}
 				},
@@ -368,6 +376,17 @@
 					"fontSize": "var(--wp--preset--font-size--small)",
 					"fontStyle": "normal",
 					"fontWeight": "600"
+				}
+			},
+			"core/comment-content": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				"spacing": {
+					"margin": {
+						"top":  "var(--wp--preset--spacing--20)",
+						"bottom":  "var(--wp--preset--spacing--20)"
+					}
 				}
 			},
 			"core/comment-date": {
@@ -378,18 +397,41 @@
 					"link": {
 						"color": {
 							"text": "var(--wp--preset--color--contrast-2)"
+						},
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
 						}
 					}
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				"spacing": {
+					"margin": {
+						"top": "0px",
+						"bottom": "0px"
+					}
 				}
 			},
 			"core/comment-edit-link": {
+				"css": "display: inline",
 				"elements": {
 					"link": {
 						"color": {
 							"text": "var(--wp--preset--color--contrast-2)"
+						},
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
 						}
 					}
 				},
@@ -398,10 +440,19 @@
 				}
 			},
 			"core/comment-reply-link": {
+				"css": "display: inline",
 				"elements": {
 					"link": {
 						"color": {
 							"text": "var(--wp--preset--color--contrast-2)"
+						},
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
 						}
 					}
 				},
@@ -428,6 +479,9 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
+			},
+			"core/comment-template": {
+				"css": "& li ol {border-left: 1px solid var(--wp--preset--color--contrast)}"
 			},
 			"core/gallery": {
 				"spacing": {


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->
Updates the comments area to match the Figma design better.
-Moves the edit link
-Removes default underline on links (shows them on :hover)
-Adds a left border to the nested comments. **We need to consider how we want to solve this for RTL.**

Figma: https://www.figma.com/file/AlYr03vh4dVimwYwQkTdf6/Twenty-Twenty-Four?node-id=507%3A1539&mode=dev

**Screenshots**
<img width="674" alt="Comments area" src="https://github.com/WordPress/twentytwentyfour/assets/7422055/018919c2-ae1b-4cdf-9805-1f7f0d784ce4">

And with pagination visible:
<img width="674" alt="comment area pagination" src="https://github.com/WordPress/twentytwentyfour/assets/7422055/090a3ea3-0876-4d4f-94e5-3bdba059bdd1">


**Testing Instructions**
View a single post that has comments.

