### PR TITLE
404 pattern update

### DIFF
--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -7,11 +7,10 @@
 
 ?>
 
-<!-- wp:heading {"textAlign":"left","level":1} -->
-<h1 class="wp-block-heading has-text-align-left" id="page-not-found"><?php echo esc_html_x( 'Page Not Found', 'Heading for a webpage that is not found', 'twentytwentyfour' ); ?></h1>
+<!-- wp:heading {"level":1} -->
+<h1 class="wp-block-heading" id="page-not-found"><?php echo esc_html_x( 'Page Not Found', 'Heading for a webpage that is not found', 'twentytwentyfour' ); ?></h1>
 <!-- /wp:heading -->
 <!-- wp:paragraph -->
 <p><?php echo esc_html_x( 'The page you are looking for doesn’t exist, or it has been moved. Please try searching using the form below.', 'Message to convey that a webpage could not be found', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
-
-<!-- wp:search {"label":"","showLabel":false,"width":620,"widthUnit":"px","buttonText":"<?php echo esc_attr_x( 'Search', 'search button', 'twentytwentyfour' ); ?>","style":{"border":{"radius":"6px"}}} /-->
+<!-- wp:search {"label":"<?php echo esc_attr_x( 'Search', 'search form label', 'twentytwentyfour' ); ?>","showLabel":false,"buttonText":"<?php echo esc_attr_x( 'Search', 'search button text', 'twentytwentyfour' ); ?>"} /-->

--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -7,12 +7,11 @@
 
 ?>
 
-<!-- wp:heading {"textAlign":"left","level":1,"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast","fontSize":"x-large"} -->
-<h1 class="wp-block-heading has-text-align-left has-contrast-color has-text-color has-link-color has-x-large-font-size" id="page-not-found"><?php echo esc_html_x( 'Page Not Found', 'Heading for a webpage that is not found', 'twentytwentyfour' ); ?></h1>
+<!-- wp:heading {"textAlign":"left","level":1} -->
+<h1 class="wp-block-heading has-text-align-left" id="page-not-found"><?php echo esc_html_x( 'Page Not Found', 'Heading for a webpage that is not found', 'twentytwentyfour' ); ?></h1>
 <!-- /wp:heading -->
-
-<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast"} -->
-<p class="has-contrast-color has-text-color has-link-color"><?php echo esc_html_x( 'The page you are looking for doesn’t exist, or it has been moved. Please try searching using the form below.', 'Message to convey that a webpage could not be found', 'twentytwentyfour' ); ?></p>
+<!-- wp:paragraph -->
+<p><?php echo esc_html_x( 'The page you are looking for doesn’t exist, or it has been moved. Please try searching using the form below.', 'Message to convey that a webpage could not be found', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:search {"label":"","showLabel":false,"width":620,"widthUnit":"px","buttonText":"<?php echo esc_attr_x( 'Search', 'search button', 'twentytwentyfour' ); ?>","style":{"border":{"radius":"6px"}}} /-->

--- a/theme.json
+++ b/theme.json
@@ -653,8 +653,8 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"lineHeight": "1.6"
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "600"
 				}
 			},
 			"core/separator": {


### PR DESCRIPTION
**Description**

- Removes colors and font sizes, to fallback on the defaults.
- Removes alignment, to fallback on the default.
- Adds a search form label (the label is still visually hidden).
- Adjusts the font size and font weight of the search block to match Figma (matches both search results page and 404).

**Testing Instructions**
View the 404 page in the editor and front.

