### PR TITLE
Updated footer for better a11y

### DIFF
--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -26,63 +26,63 @@
 <!-- wp:column {"width":"50%","style":{"spacing":{"padding":{"top":"var:preset|spacing|30"}}}} -->
 <div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--30);flex-basis:50%"><!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium"} -->
-<p class="has-medium-font-size" style="font-style:normal;font-weight:600">About</p>
-<!-- /wp:paragraph -->
+<div class="wp-block-group"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium","fontFamily":"system-font"} -->
+<h3 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:600">About</h3>
+<!-- /wp:heading -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size">Team</p>
-<!-- /wp:paragraph -->
+<div class="wp-block-group">
 
-<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size">History</p>
-<!-- /wp:paragraph -->
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} -->
 
-<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size">Careers</p>
-<!-- /wp:paragraph --></div>
+<!-- wp:navigation-link {"label":"Team","url":"#"} /-->
+<!-- wp:navigation-link {"label":"History","url":"#"} /-->
+<!-- wp:navigation-link {"label":"Careers","url":"#"} /-->
+
+<!-- /wp:navigation -->
+
+</div>
 <!-- /wp:group --></div>
 
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium"} -->
-<p class="has-medium-font-size" style="font-style:normal;font-weight:600">Privacy</p>
-<!-- /wp:paragraph -->
+<div class="wp-block-group"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium","fontFamily":"system-font"} -->
+<h3 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:600">Privacy</h3>
+<!-- /wp:heading -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size">Privacy Policy</p>
-<!-- /wp:paragraph -->
+<div class="wp-block-group">
+	
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} -->
 
-<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size">Terms and Conditions</p>
-<!-- /wp:paragraph -->
+<!-- wp:navigation-link {"label":"Privacy Policy","url":"#"} /-->
+<!-- wp:navigation-link {"label":"Terms and Conditions","url":"#"} /-->
+<!-- wp:navigation-link {"label":"Contact Us","url":"#"} /-->
 
-<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size">Contact Us</p>
-<!-- /wp:paragraph --></div>
+<!-- /wp:navigation -->
+
+</div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium"} -->
-<p class="has-medium-font-size" style="font-style:normal;font-weight:600">Social Media</p>
-<!-- /wp:paragraph -->
+<div class="wp-block-group"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium","fontFamily":"system-font"} -->
+<h3 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:600">Social Media</h3>
+<!-- /wp:heading -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size">Facebook</p>
-<!-- /wp:paragraph -->
+<div class="wp-block-group">
 
-<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size">Instagram</p>
-<!-- /wp:paragraph -->
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} -->
 
-<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size">Twitter/X</p>
-<!-- /wp:paragraph --></div>
+<!-- wp:navigation-link {"label":"Facebook","url":"#"} /-->
+<!-- wp:navigation-link {"label":"Instagram","url":"#"} /-->
+<!-- wp:navigation-link {"label":"Twitter/X","url":"#"} /-->
+
+<!-- /wp:navigation -->
+
+</div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Closes https://github.com/WordPress/twentytwentyfour/issues/12

This PR adds headings to the footer instead of paragraphs and makes the links into nav blocks with custom placeholder content.

I think this is the best compromise between a11y concerns and the design given. We don't have a native solution for this kind of menu design yet, and I don't want to add the extra CSS for this that will be hard for a user to make it work if they want to make changes to it.

I'm not too sure about the headings here, but it was [suggested](https://github.com/WordPress/twentytwentyfour/issues/12#issuecomment-1716053412) they should be. Maybe they need to be h2s in case the page doesn't contain any h2s themselves, since the footer will be used on all pages. I'm not sure how semantic that is, happy to hear any thoughts in that regard.

/cc @mrwweb
