### PR TITLE
Remove page-alternative template reference from theme.json

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -960,13 +960,6 @@
 			"title": "Page Portfolio"
 		},
 		{
-			"name": "page-alternative",
-			"postTypes": [
-				"page"
-			],
-			"title": "Page Alternative"
-		},
-		{
 			"name": "single-writer",
 			"postTypes": [
 				"post"


### PR DESCRIPTION
The template has been removed earlier, but there was still a reference to it in the theme.json.