### PR TITLE
Reduce left padding of lists

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -503,7 +503,7 @@
 			"core/list": {
 				"spacing": {
 					"padding": {
-						"left": "var(--wp--preset--spacing--70)"
+						"left": "var(--wp--preset--spacing--10)"
 					}
 				}
 			},


### PR DESCRIPTION
**Description**

To match the Figma design for lists, they should align with the heading. This change adds a small padding, so the list items align nicely with the heading.

**Screenshots**

<img width="400" alt="CleanShot 2023-09-13 at 12 20 10@2x" src="https://github.com/WordPress/twentytwentyfour/assets/7585600/24c85715-5736-4473-9280-6adeea114d7a">

**Testing Instructions**

1. Create/open a post/page
2. Add an unordered or ordered list
3. Check the left alignment