### PR TITLE
Pullquote: make cite sans-serif

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -630,9 +630,6 @@
 						"width": "0px"
 					}
 				},
-				"color": {
-					"background": "var(--wp--preset--color--tertiary)"
-				},
 				"elements": {
 					"cite": {
 						"typography": {

--- a/theme.json
+++ b/theme.json
@@ -633,6 +633,15 @@
 				"color": {
 					"background": "var(--wp--preset--color--tertiary)"
 				},
+				"elements": {
+					"cite": {
+						"typography": {
+							"fontFamily": "var(--wp--preset--font-family--system-font)",
+							"fontSize": "var(--wp--preset--font-size--medium)",
+							"fontStyle": "normal"
+						}
+					}
+				},
 				"spacing": {
 					"padding": {
 						"bottom": "var(--wp--preset--spacing--50)",


### PR DESCRIPTION
**Description**

This PR adds some code to make the pullquote citation sans-serif as designed in the Figma file.

**Screenshots**

<img width="1021" alt="CleanShot 2023-09-13 at 12 47 02@2x" src="https://github.com/WordPress/twentytwentyfour/assets/7585600/6db62ff2-41b7-4636-a0f8-01014e2b5e6c">

**Testing Instructions**

1. Create/open a post/page
2. Add pullquote
3. Add citation
