### PR TITLE
Add border to default button to match size with outlined button

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -780,7 +780,24 @@
 					}
 				},
 				"border": {
-					"radius": ".33rem"
+					"radius": ".33rem",
+					"color": "var(--wp--preset--color--contrast)",
+					"bottom": {
+						"style": "solid",
+						"width": "1px"
+					},
+					"left": {
+						"style": "solid",
+						"width": "1px"
+					},
+					"right": {
+						"style": "solid",
+						"width": "1px"
+					},
+					"top": {
+						"style": "solid",
+						"width": "1px"
+					}
 				},
 				"color": {
 					"background": "var(--wp--preset--color--contrast)",


### PR DESCRIPTION
**Description**

This PR adds a border for the default buttons, which currently do not have one. Putting a default button and an outlined button side by side, there's a minor difference in size, as the outlined button has the border, the default has not.

**Screenshots**

Before:
<img width="286" alt="CleanShot 2023-09-13 at 13 26 07@2x" src="https://github.com/WordPress/twentytwentyfour/assets/7585600/54a63a90-24e5-4dc3-93ac-f98a280b2ba5">

After:
<img width="293" alt="CleanShot 2023-09-13 at 13 25 33@2x" src="https://github.com/WordPress/twentytwentyfour/assets/7585600/a10f3373-33da-4768-99b7-2a53221eaac3">


**Testing Instructions**

1. Create/open a post/page
2. Add a pattern with both buttons or create a new buttons block, add two buttons with one being default and the other outlined