### PR TITLE
Bump @wordpress/stylelint-config from 20.0.2 to 21.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
 			"version": "0.0.1",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@wordpress/stylelint-config": "^20.0.2",
-				"stylelint": "^14.10.0"
+				"@wordpress/stylelint-config": "^21.24.0",
+				"stylelint": "^14.16.1"
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.22.10",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
-			"integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
+			"version": "7.22.13",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+			"integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.22.10",
+				"@babel/highlight": "^7.22.13",
 				"chalk": "^2.4.2"
 			},
 			"engines": {
@@ -27,18 +27,18 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-			"integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
+			"integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.22.10",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
-			"integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
+			"version": "7.22.13",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
+			"integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.22.5",
@@ -119,16 +119,16 @@
 			"dev": true
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-20.0.3.tgz",
-			"integrity": "sha512-J+bByJYLkc+pCFzDekIEVQq513It+4XnLbQLn5KFcYD0ztk4KJsnNfU/uY8t9BAhfJfX8spwLo+tUwMF47tUTQ==",
+			"version": "21.24.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.24.0.tgz",
+			"integrity": "sha512-GJV0rSQL5iTcS/mJ7x/ccZ7Z06yYJhDY0XWNA3qVRNMgkV/iyv2rXNNubpDl+m4kcgi8g3dg3jNccvRO1ZDSgg==",
 			"dev": true,
 			"dependencies": {
 				"stylelint-config-recommended": "^6.0.0",
 				"stylelint-config-recommended-scss": "^5.0.2"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14"
 			},
 			"peerDependencies": {
 				"stylelint": "^14.2"
@@ -510,16 +510,17 @@
 			}
 		},
 		"node_modules/flat-cache": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
+			"integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
 			"dev": true,
 			"dependencies": {
-				"flatted": "^3.1.0",
+				"flatted": "^3.2.7",
+				"keyv": "^4.5.3",
 				"rimraf": "^3.0.2"
 			},
 			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/flatted": {
@@ -848,6 +849,12 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true
 		},
+		"node_modules/json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true
+		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -859,6 +866,15 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"dev": true
+		},
+		"node_modules/keyv": {
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+			"integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+			"dev": true,
+			"dependencies": {
+				"json-buffer": "3.0.1"
+			}
 		},
 		"node_modules/kind-of": {
 			"version": "6.0.3",
@@ -1191,9 +1207,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.28",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
-			"integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
+			"version": "8.4.29",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.29.tgz",
+			"integrity": "sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==",
 			"dev": true,
 			"funding": [
 				{
@@ -1247,9 +1263,9 @@
 			}
 		},
 		"node_modules/postcss-scss": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.7.tgz",
-			"integrity": "sha512-xPv2GseoyXPa58Nro7M73ZntttusuCmZdeOojUFR5PZDz2BR62vfYx1w9TyOnp1+nYFowgOMipsCBhxzVkAEPw==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.8.tgz",
+			"integrity": "sha512-Cr0X8Eu7xMhE96PJck6ses/uVVXDtE5ghUTKNUYgm8ozgP2TkgV3LWs3WgLV1xaSSLq8ZFiXaUrj0LVgG1fGEA==",
 			"dev": true,
 			"funding": [
 				{
@@ -1269,7 +1285,7 @@
 				"node": ">=12.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.4.19"
+				"postcss": "^8.4.29"
 			}
 		},
 		"node_modules/postcss-selector-parser": {
@@ -1963,25 +1979,25 @@
 	},
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.22.10",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
-			"integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
+			"version": "7.22.13",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+			"integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.22.10",
+				"@babel/highlight": "^7.22.13",
 				"chalk": "^2.4.2"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-			"integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
+			"integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.22.10",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
-			"integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
+			"version": "7.22.13",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
+			"integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.22.5",
@@ -2041,9 +2057,9 @@
 			"dev": true
 		},
 		"@wordpress/stylelint-config": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-20.0.3.tgz",
-			"integrity": "sha512-J+bByJYLkc+pCFzDekIEVQq513It+4XnLbQLn5KFcYD0ztk4KJsnNfU/uY8t9BAhfJfX8spwLo+tUwMF47tUTQ==",
+			"version": "21.24.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.24.0.tgz",
+			"integrity": "sha512-GJV0rSQL5iTcS/mJ7x/ccZ7Z06yYJhDY0XWNA3qVRNMgkV/iyv2rXNNubpDl+m4kcgi8g3dg3jNccvRO1ZDSgg==",
 			"dev": true,
 			"requires": {
 				"stylelint-config-recommended": "^6.0.0",
@@ -2340,12 +2356,13 @@
 			}
 		},
 		"flat-cache": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
+			"integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
 			"dev": true,
 			"requires": {
-				"flatted": "^3.1.0",
+				"flatted": "^3.2.7",
+				"keyv": "^4.5.3",
 				"rimraf": "^3.0.2"
 			}
 		},
@@ -2596,6 +2613,12 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true
 		},
+		"json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true
+		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -2607,6 +2630,15 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"dev": true
+		},
+		"keyv": {
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+			"integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+			"dev": true,
+			"requires": {
+				"json-buffer": "3.0.1"
+			}
 		},
 		"kind-of": {
 			"version": "6.0.3",
@@ -2845,9 +2877,9 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "8.4.28",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
-			"integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
+			"version": "8.4.29",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.29.tgz",
+			"integrity": "sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==",
 			"dev": true,
 			"requires": {
 				"nanoid": "^3.3.6",
@@ -2875,9 +2907,9 @@
 			"requires": {}
 		},
 		"postcss-scss": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.7.tgz",
-			"integrity": "sha512-xPv2GseoyXPa58Nro7M73ZntttusuCmZdeOojUFR5PZDz2BR62vfYx1w9TyOnp1+nYFowgOMipsCBhxzVkAEPw==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.8.tgz",
+			"integrity": "sha512-Cr0X8Eu7xMhE96PJck6ses/uVVXDtE5ghUTKNUYgm8ozgP2TkgV3LWs3WgLV1xaSSLq8ZFiXaUrj0LVgG1fGEA==",
 			"dev": true,
 			"requires": {}
 		},

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
 		"url": "https://github.com/WordPress/twentytwentyfour/issues"
 	},
 	"devDependencies": {
-		"@wordpress/stylelint-config": "^20.0.2",
-		"stylelint": "^14.10.0"
+		"@wordpress/stylelint-config": "^21.24.0",
+		"stylelint": "^14.16.1"
 	},
 	"scripts": {
 		"lint:css": "stylelint **/*.css -i .gitignore",


### PR DESCRIPTION
**Description**

- Bump @wordpress/stylelint-config from 20.0.2 to 21.24.0
- Bump stylelint from 14.10.0 to 14.16.1

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

**Testing Instructions**

<!-- Provide steps for testing -->
<!-- 1. Activate the theme. -->
<!-- 2. Visit the archives page. -->
<!-- 3. etc. -->

**Contributors**

<!-- Please ensure anyone who contributed on linked issues and within this pull request have _AT LEAST_ their GitHub Username listed in the `CONTRIBUTORS.md` file as part of this PR. -->
