### PR TITLE
Update .is-style-default to .is-style-wide for Separator

### DIFF
--- a/patterns/faq.php
+++ b/patterns/faq.php
@@ -13,8 +13,8 @@
 <!-- /wp:heading -->
 
 <!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
-<div class="wp-block-group alignwide"><!-- wp:separator {"style":{"color":{"background":"#ffffff1a"}},"className":"is-style-default"} -->
-<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background is-style-default" style="background-color:#ffffff1a;color:#ffffff1a"/>
+<div class="wp-block-group alignwide"><!-- wp:separator {"style":{"color":{"background":"#ffffff1a"}},"className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background is-style-wide" style="background-color:#ffffff1a;color:#ffffff1a"/>
 <!-- /wp:separator -->
 
 <!-- wp:details {"style":{"spacing":{"margin":{"top":"0"}}},"className":"is-style-arrow-icon-details","fontSize":"medium"} -->


### PR DESCRIPTION
**Description**

Addresses #341 where the `<hr>` lost its wideness.

**Screenshots**

| Before | After |
|---------|------------|
| ![Screenshot 2023-09-13 at 11 28 08 AM](https://github.com/WordPress/twentytwentyfour/assets/405912/10977671-9838-43e1-b09b-a89c924b39b6) | ![Screenshot 2023-09-13 at 11 27 38 AM](https://github.com/WordPress/twentytwentyfour/assets/405912/7b77c3fa-de22-4b14-8f42-af66e01f39c9) |
