### PR TITLE
Try: add a block style for separator blocks that turns them into asterisks

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -80,6 +80,13 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				'label' => __( 'Pill', 'twentytwentyfour' ),
 			)
 		);
+		register_block_style(
+			'core/separator',
+			array(
+				'name'  => 'asterisk',
+				'label' => __( 'Asterisk', 'twentytwentyfour' ),
+			)
+		);
 	}
 endif;
 

--- a/patterns/feature-grid.php
+++ b/patterns/feature-grid.php
@@ -9,9 +9,11 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"backgroundColor":"base-2","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-base-2-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"center","textColor":"base-3","fontSize":"large"} -->
-<p class="has-text-align-center has-base-3-color has-text-color has-large-font-size">✳︎</p>
-<!-- /wp:paragraph -->
+<div class="wp-block-group">
+
+<!-- wp:separator {"backgroundColor":"base-3","className":"is-style-asterisk"} -->
+<hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-base-3-background-color has-background is-style-asterisk"/>
+<!-- /wp:separator -->
 
 <!-- wp:heading {"textAlign":"center"} -->
 <h2 class="wp-block-heading has-text-align-center"><?php echo esc_html_x( 'A passion for creating spaces', 'Heading of the features', 'twentytwentyfour' ); ?></h2>

--- a/style.css
+++ b/style.css
@@ -35,7 +35,7 @@ a {
 }
 
 /*
- * Styles for the custom Faq arrow details block style
+ * Block style for the custom Faq arrow details block style
  * https://github.com/WordPress/twentytwentyfour/issues/46
  */
 
@@ -54,7 +54,7 @@ a {
 }
 
 /*
- * Styles variation for post terms
+ * Block style for post terms
  * https://github.com/WordPress/gutenberg/issues/24956
  */
 
@@ -70,4 +70,16 @@ a {
 
 .is-style-pill a:hover {
 	background:#eee;
+}
+
+/*
+ * Block style for post separator
+ */
+
+.is-style-asterisk.wp-block-separator:not(.is-style-wide):not(.is-style-dots):not(.alignwide):not(.alignfull) {
+	border: none;
+	width: 22px;
+	height: 21px;
+	background: currentColor;
+	clip-path: path('M11.93.684v8.039l5.633-5.633 1.216 1.23-5.66 5.66h8.04v1.737H13.2l5.701 5.701-1.23 1.23-5.742-5.742V21h-1.737v-8.094l-5.77 5.77-1.23-1.217 5.743-5.742H.842V9.98h8.162l-5.701-5.7 1.23-1.231 5.66 5.66V.684h1.737Z');
 }


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Alternative to https://github.com/WordPress/twentytwentyfour/pull/51

Uses SVG and clip path to turn the separator into an asterisk. This is a proof of concept, we got to figure out:

- how to tinker with the alignment of the separator
- If we are happy with using the hr for this particular case
- if using px units to lock in the size of the icon is ok

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

This screenshot shows: 
- the old paragraph block with the glyph
- 3 separator blocks with different colors applied to it

<img width="653" alt="Screenshot 2023-09-14 at 10 58 59" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/19a4f6eb-6d6f-48b4-8e64-6dc51431e488">


**Testing Instructions**

<!-- Provide steps for testing -->
<!-- 1. Activate the theme. -->
<!-- 2. Visit the archives page. -->
<!-- 3. etc. -->

Add a separator block and check the asterisk block style for it


