### PR TITLE
Use font slugs

### DIFF
--- a/patterns/about-2.php
+++ b/patterns/about-2.php
@@ -14,8 +14,8 @@
 <div class="wp-block-column is-vertically-aligned-stretch" style="flex-basis:50%"><!-- wp:group {"style":{"dimensions":{"minHeight":"100%"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch","verticalAlignment":"space-between"}} -->
 <div class="wp-block-group" style="min-height:100%">
 
-<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large","fontFamily":"cardo"} -->
-<p class="has-cardo-font-family has-x-large-font-size" style="line-height:1.2"><?php echo esc_html_x( 'Études offers comprehensive consulting, management, design, and research solutions. Every architectural endeavor is an opportunity to shape the future.', 'Headline for the About pattern', 'twentytwentyfour' ); ?></p>
+<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large","fontFamily":"heading"} -->
+<p class="has-heading-font-family has-x-large-font-size" style="line-height:1.2"><?php echo esc_html_x( 'Études offers comprehensive consulting, management, design, and research solutions. Every architectural endeavor is an opportunity to shape the future.', 'Headline for the About pattern', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:group {"layout":{"type":"constrained","contentSize":"300px","justifyContent":"left"}} -->

--- a/patterns/about.php
+++ b/patterns/about.php
@@ -7,8 +7,8 @@
 
 ?>
 
-<!-- wp:paragraph {"align":"center","style":{"typography":{"fontStyle":"italic","fontWeight":"400","lineHeight":"1.3"},"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"backgroundColor":"base","fontSize":"large","fontFamily":"cardo"} -->
-<p class="has-text-align-center has-base-background-color has-background has-cardo-font-family has-large-font-size" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);font-style:italic;font-weight:400;line-height:1.3">
+<!-- wp:paragraph {"align":"center","style":{"typography":{"fontStyle":"italic","fontWeight":"400","lineHeight":"1.3"},"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"backgroundColor":"base","fontSize":"large","fontFamily":"heading"} -->
+<p class="has-text-align-center has-base-background-color has-background has-heading-font-family has-large-font-size" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);font-style:italic;font-weight:400;line-height:1.3">
 	<?php
 		/* Translators: About link placeholder */
 		$about_link = '<a href="#" rel="nofollow">' . esc_html__( 'Money Studies', 'twentytwentyfour' ) . '</a>';

--- a/patterns/centered-statement.php
+++ b/patterns/centered-statement.php
@@ -9,8 +9,8 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}},"border":{"radius":"16px"}},"backgroundColor":"base-2","layout":{"type":"default"}} -->
-<div class="wp-block-group alignwide has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:paragraph {"align":"center","style":{"typography":{"lineHeight":"1.2","fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-large","fontFamily":"cardo"} -->
-<p class="has-text-align-center has-cardo-font-family has-x-large-font-size" style="font-style:normal;font-weight:400;line-height:1.2">
+<div class="wp-block-group alignwide has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:paragraph {"align":"center","style":{"typography":{"lineHeight":"1.2","fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-large","fontFamily":"heading"} -->
+<p class="has-text-align-center has-heading-font-family has-x-large-font-size" style="font-style:normal;font-weight:400;line-height:1.2">
 <?php
 		echo sprintf(
 			'%1$s<em>%2$s</em>%3$s',

--- a/patterns/columns.php
+++ b/patterns/columns.php
@@ -11,8 +11,8 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|40","left":"var:preset|spacing|40"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"33%"} -->
-<div class="wp-block-column" style="flex-basis:33%"><!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"large","fontFamily":"cardo"} -->
-<p class="has-cardo-font-family has-large-font-size" style="line-height:1.2"><?php echo esc_html__( 'We recognize the role architecture plays in shaping a sustainable future.', 'twentytwentyfour' ); ?></p>
+<div class="wp-block-column" style="flex-basis:33%"><!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"large","fontFamily":"heading"} -->
+<p class="has-heading-font-family has-large-font-size" style="line-height:1.2"><?php echo esc_html__( 'We recognize the role architecture plays in shaping a sustainable future.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 

--- a/patterns/footer-portfolio.php
+++ b/patterns/footer-portfolio.php
@@ -19,8 +19,8 @@
 
 <!-- wp:columns {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10"}}}} -->
 <div class="wp-block-columns" style="padding-top:var(--wp--preset--spacing--10)"><!-- wp:column {"width":"57%"} -->
-<div class="wp-block-column" style="flex-basis:57%"><!-- wp:paragraph {"fontSize":"x-large","fontFamily":"cardo"} -->
-<p class="has-cardo-font-family has-x-large-font-size">Keep up, get in touch.</p>
+<div class="wp-block-column" style="flex-basis:57%"><!-- wp:paragraph {"fontSize":"x-large","fontFamily":"heading"} -->
+<p class="has-heading-font-family has-x-large-font-size">Keep up, get in touch.</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -26,7 +26,7 @@
 <!-- wp:column {"width":"50%","style":{"spacing":{"padding":{"top":"var:preset|spacing|30"}}}} -->
 <div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--30);flex-basis:50%"><!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-<div class="wp-block-group"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium","fontFamily":"system-font"} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium","fontFamily":"body"} -->
 <h3 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:600">About</h3>
 <!-- /wp:heading -->
 
@@ -47,13 +47,13 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-<div class="wp-block-group"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium","fontFamily":"system-font"} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium","fontFamily":"body"} -->
 <h3 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:600">Privacy</h3>
 <!-- /wp:heading -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group">
-	
+
 <!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} -->
 
 <!-- wp:navigation-link {"label":"Privacy Policy","url":"#"} /-->
@@ -67,7 +67,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-<div class="wp-block-group"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium","fontFamily":"system-font"} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium","fontFamily":"body"} -->
 <h3 class="wp-block-heading has-system-font-font-family has-medium-font-size" style="font-style:normal;font-weight:600">Social Media</h3>
 <!-- /wp:heading -->
 

--- a/patterns/hidden-hidden-intro-text-left.php
+++ b/patterns/hidden-hidden-intro-text-left.php
@@ -18,8 +18,8 @@
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"70%"} -->
 <div class="wp-block-column" style="flex-basis:70%">
 
-<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"xx-large","fontFamily":"cardo"} -->
-<p class="has-cardo-font-family has-xx-large-font-size" style="line-height:1.2">Sono <em>Leia Acosta</em>, una fotografa appassionata che trova ispirazione nel catturare la bellezza fugace della vita.</p>
+<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"xx-large","fontFamily":"heading"} -->
+<p class="has-heading-font-family has-xx-large-font-size" style="line-height:1.2">Sono <em>Leia Acosta</em>, una fotografa appassionata che trova ispirazione nel catturare la bellezza fugace della vita.</p>
 <!-- /wp:paragraph -->
 </div>
 <!-- /wp:column -->

--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -63,7 +63,7 @@
 <!-- wp:query {"queryId":13,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
 <!-- wp:group {"style":{"spacing":{"blockGap":"0.5rem"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"fontSize":"small","fontFamily":"system-font"} /--></div>
+<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"fontSize":"small","fontFamily":"body"} /--></div>
 <!-- /wp:group -->
 <!-- /wp:post-template --></div>
 <!-- /wp:query --></div>

--- a/patterns/project-description.php
+++ b/patterns/project-description.php
@@ -17,8 +17,8 @@
 <!-- wp:column {"width":"60%"} -->
 <div class="wp-block-column" style="flex-basis:60%">
 
-<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large","fontFamily":"cardo"} -->
-<p class="has-cardo-font-family has-x-large-font-size" style="line-height:1.2"><?php echo esc_html_x( 'This transformative project seeks to enhance the gallery\'s infrastructure, accessibility, and exhibition spaces while preserving its rich cultural heritage.', 'A heading type project description.', 'twentytwentyfour' ); ?></p>
+<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large","fontFamily":"heading"} -->
+<p class="has-heading-font-family has-x-large-font-size" style="line-height:1.2"><?php echo esc_html_x( 'This transformative project seeks to enhance the gallery\'s infrastructure, accessibility, and exhibition spaces while preserving its rich cultural heritage.', 'A heading type project description.', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 </div>

--- a/patterns/project-details.php
+++ b/patterns/project-details.php
@@ -21,8 +21,8 @@
 <!-- wp:column {"width":"60%","style":{"spacing":{"blockGap":"var:preset|spacing|40"}}} -->
 <div class="wp-block-column" style="flex-basis:60%">
 
-<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large","fontFamily":"cardo"} -->
-<p class="has-cardo-font-family has-x-large-font-size" style="line-height:1.2">With meticulous attention to detail and a commitment to excellence, we create spaces that inspire, elevate, and enrich the lives of those who inhabit them.</p>
+<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large","fontFamily":"heading"} -->
+<p class="has-heading-font-family has-x-large-font-size" style="line-height:1.2">With meticulous attention to detail and a commitment to excellence, we create spaces that inspire, elevate, and enrich the lives of those who inhabit them.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->

--- a/patterns/rsvp.php
+++ b/patterns/rsvp.php
@@ -13,8 +13,8 @@
 <div class="wp-block-column is-vertically-aligned-stretch" style="flex-basis:50%"><!-- wp:group {"style":{"dimensions":{"minHeight":"100%"},"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left","verticalAlignment":"space-between"}} -->
 <div class="wp-block-group" style="min-height:100%">
 
-<!-- wp:paragraph {"align":"right","style":{"typography":{"writingMode":"vertical-rl","fontSize":"12rem","lineHeight":"1"},"spacing":{"margin":{"right":"0","left":"calc( var(--wp--preset--spacing--30) * -1)"}}},"fontFamily":"cardo"} -->
-<p class="has-text-align-right has-cardo-font-family" style="margin-right:0;margin-left:calc( var(--wp--preset--spacing--30) * -1);font-size:12rem;line-height:1;writing-mode:vertical-rl"><?php echo esc_html_x( 'RSVP', 'Initials for ´please respond´', 'twentytwentyfour' ); ?></p>
+<!-- wp:paragraph {"align":"right","style":{"typography":{"writingMode":"vertical-rl","fontSize":"12rem","lineHeight":"1"},"spacing":{"margin":{"right":"0","left":"calc( var(--wp--preset--spacing--30) * -1)"}}},"fontFamily":"heading"} -->
+<p class="has-text-align-right has-heading-font-family" style="margin-right:0;margin-left:calc( var(--wp--preset--spacing--30) * -1);font-size:12rem;line-height:1;writing-mode:vertical-rl"><?php echo esc_html_x( 'RSVP', 'Initials for ´please respond´', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:group {"layout":{"type":"constrained","contentSize":"300px","justifyContent":"left"}} -->

--- a/patterns/testimonial.php
+++ b/patterns/testimonial.php
@@ -9,8 +9,8 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60","right":"var:preset|spacing|60"}}},"backgroundColor":"contrast","textColor":"base","layout":{"type":"default"}} -->
 <div class="wp-block-group alignfull has-base-color has-contrast-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
 
-<!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"bottom":"2rem"},"padding":{"right":"0","left":"0"}},"typography":{"lineHeight":"1.2","letterSpacing":"-0.02em"}},"textColor":"base","fontSize":"x-large","fontFamily":"cardo"} -->
-<p class="has-text-align-center has-base-color has-text-color has-cardo-font-family has-x-large-font-size" style="margin-bottom:2rem;padding-right:0;padding-left:0;letter-spacing:-0.02em;line-height:1.2"><em><?php echo esc_html_x( '“Études has saved us thousands of hours of work and has unlocked insights we never thought possible.”', 'Testimonial Text or Review Text Got From the Person', 'twentytwentyfour' ); ?></em></p>
+<!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"bottom":"2rem"},"padding":{"right":"0","left":"0"}},"typography":{"lineHeight":"1.2","letterSpacing":"-0.02em"}},"textColor":"base","fontSize":"x-large","fontFamily":"heading"} -->
+<p class="has-text-align-center has-base-color has-text-color has-heading-font-family has-x-large-font-size" style="margin-bottom:2rem;padding-right:0;padding-left:0;letter-spacing:-0.02em;line-height:1.2"><em><?php echo esc_html_x( '“Études has saved us thousands of hours of work and has unlocked insights we never thought possible.”', 'Testimonial Text or Review Text Got From the Person', 'twentytwentyfour' ); ?></em></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"align":"center","width":64,"height":64,"scale":"cover","sizeSlug":"thumbnail","linkDestination":"none","style":{"border":{"radius":"999px"}},"className":"is-style-rounded"} -->

--- a/theme.json
+++ b/theme.json
@@ -251,7 +251,7 @@
 						}
 					],
 					"fontFamily": "Cardo",
-					"slug": "cardo"
+					"slug": "heading"
 				}
 			],
 			"fontSizes": [
@@ -648,7 +648,7 @@
 					}
 				},
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--cardo)",
+					"fontFamily": "var(--wp--preset--font-family--heading)",
 					"fontSize": "var(--wp--preset--font-size--x-large)",
 					"fontStyle": "italic",
 					"fontWeight": "400",
@@ -685,7 +685,7 @@
 					}
 				},
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--cardo)",
+					"fontFamily": "var(--wp--preset--font-family--heading)",
 					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontStyle": "italic",
 					"lineHeight": "1.3"
@@ -874,7 +874,7 @@
 					"text": "var(--wp--preset--color--contrast)"
 				},
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--cardo)",
+					"fontFamily": "var(--wp--preset--font-family--heading)",
 					"fontWeight": "400",
 					"lineHeight": "1.2"
 				}

--- a/theme.json
+++ b/theme.json
@@ -221,7 +221,7 @@
 				{
 					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
 					"name": "System Font",
-					"slug": "system-font"
+					"slug": "body"
 				},
 				{
 					"fontFace": [
@@ -670,7 +670,7 @@
 				"elements": {
 					"cite": {
 						"typography": {
-							"fontFamily": "var(--wp--preset--font-family--system-font)",
+							"fontFamily": "var(--wp--preset--font-family--body)",
 							"fontSize": "var(--wp--preset--font-size--small)",
 							"fontStyle": "normal"
 						}
@@ -754,7 +754,7 @@
 					}
 				},
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
+					"fontFamily": "var(--wp--preset--font-family--body)",
 					"fontSize": "1.2rem",
 					"fontStyle": "normal",
 					"fontWeight": "600"
@@ -834,7 +834,7 @@
 					"text": "var(--wp--preset--color--contrast-2)"
 				},
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
+					"fontFamily": "var(--wp--preset--font-family--body)",
 					"fontSize": "0.8rem"
 				}
 			},
@@ -898,7 +898,7 @@
 			}
 		},
 		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--system-font)",
+			"fontFamily": "var(--wp--preset--font-family--body)",
 			"fontSize": "var(--wp--preset--font-size--medium)",
 			"fontStyle": "normal",
 			"fontWeight": "400",

--- a/theme.json
+++ b/theme.json
@@ -633,7 +633,7 @@
 				"elements": {
 					"cite": {
 						"typography": {
-							"fontFamily": "var(--wp--preset--font-family--system-font)",
+							"fontFamily": "var(--wp--preset--font-family--body)",
 							"fontSize": "var(--wp--preset--font-size--medium)",
 							"fontStyle": "normal"
 						}


### PR DESCRIPTION
**Description**

Uses `heading` as a font family slug, instead of `cardo` so that there is a default heading font that can be changed by variations, and patterns can inherit the new style's `heading` font. And the same for `body` font. 

This is how colors and spacing works, so that variations can change them holistically. 

**Screenshots**
No visual change. The font family is still named "Cardo" in the UI. 

<img width="280" alt="CleanShot 2023-09-14 at 13 35 52" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/66a1916e-ad1e-4bd9-b651-1f3590d2fefe">
