### PR TITLE
Block style for checkmarks

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -80,6 +80,13 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				'label' => __( 'Pill', 'twentytwentyfour' ),
 			)
 		);
+		register_block_style(
+			'core/list',
+			array(
+				'name'         => 'checkmark-list',
+				'label'        => __( 'Checkmarks', 'twentytwentyfour' ),
+			)
+		);
 	}
 endif;
 

--- a/functions.php
+++ b/functions.php
@@ -83,8 +83,8 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 		register_block_style(
 			'core/list',
 			array(
-				'name'         => 'checkmark-list',
-				'label'        => __( 'Checkmarks', 'twentytwentyfour' ),
+				'name'  => 'checkmark-list',
+				'label' => __( 'Checkmark', 'twentytwentyfour' ),
 			)
 		);
 	}

--- a/patterns/features-with-images.php
+++ b/patterns/features-with-images.php
@@ -37,9 +37,22 @@
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 
-<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.8"}}} -->
-<p style="line-height:1.8"><?php echo esc_html_x( '✓ Collaborate with fellow architects', 'A general list item.', 'twentytwentyfour' ); ?><br><?php echo esc_html_x( '✓ Showcase your projects', 'A general list item.', 'twentytwentyfour' ); ?><br><?php echo esc_html_x( '✓ Experience the world of architecture like never before', 'A general list item.', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph --></div>
+<!-- wp:list {"style":{"typography":{"lineHeight":"1.75"}},"className":"is-style-checkmark-list"} -->
+<ul class="is-style-checkmark-list" style="line-height:1.75">
+	<!-- wp:list-item -->
+	<li><?php echo esc_html_x( 'Collaborate with fellow architects', 'A general list item.', 'twentytwentyfour' ); ?></li>
+	<!-- /wp:list-item -->
+
+	<!-- wp:list-item -->
+	<li><?php echo esc_html_x( 'Showcase your projects', 'A general list item.', 'twentytwentyfour' ); ?></li>
+	<!-- /wp:list-item -->
+
+	<!-- wp:list-item -->
+	<li><?php echo esc_html_x( 'Experience the world of architecture like never before', 'A general list item.', 'twentytwentyfour' ); ?></li>
+	<!-- /wp:list-item -->
+</ul>
+<!-- /wp:list -->
+</div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
@@ -71,8 +84,22 @@
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 
-<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.8"}}} -->
-<p style="line-height:1.8"><?php echo esc_html_x( '✓ Dive into a world of thought-provoking articles', 'A general list item.', 'twentytwentyfour' ); ?><br><?php echo esc_html_x( '✓ Read case studies that celebrate the artistry of architecture', 'A general list item.', 'twentytwentyfour' ); ?><br><?php echo esc_html_x( '✓ Gain exclusive access to design insights', 'A general list item.', 'twentytwentyfour' ); ?></p>
+<!-- wp:list {"style":{"typography":{"lineHeight":"1.75"}},"className":"is-style-checkmark-list"} -->
+<ul class="is-style-checkmark-list" style="line-height:1.75">
+	<!-- wp:list-item -->
+	<li><?php echo esc_html_x( 'Dive into a world of thought-provoking articles', 'A general list item.', 'twentytwentyfour' ); ?></li>
+	<!-- /wp:list-item -->
+
+	<!-- wp:list-item -->
+	<li><?php echo esc_html_x( 'Read case studies that celebrate the artistry of architecture', 'A general list item.', 'twentytwentyfour' ); ?></li>
+	<!-- /wp:list-item -->
+
+	<!-- wp:list-item -->
+	<li><?php echo esc_html_x( 'Gain exclusive access to design insights', 'A general list item.', 'twentytwentyfour' ); ?></li>
+	<!-- /wp:list-item -->
+</ul>
+<!-- /wp:list -->
+</div>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>

--- a/patterns/left-aligned-cta-image.php
+++ b/patterns/left-aligned-cta-image.php
@@ -16,18 +16,18 @@
 			<h2 class="wp-block-heading"><?php echo esc_html_x( 'Enhance your architectural journey with the Études Architect App', 'sample heading for call to action', 'twentytwentyfour' ); ?></h2>
 			<!-- /wp:heading -->
 
-			<!-- wp:list {"style":{"typography":{"lineHeight":"1.75"}}} -->
-			<ul style="line-height:1.75">
+			<!-- wp:list {"style":{"typography":{"lineHeight":"1.75"}},"className":"is-style-checkmark-list"} -->
+			<ul class="is-style-checkmark-list" style="line-height:1.75">
 				<!-- wp:list-item -->
-				<li><?php echo esc_html_x( 'Collaborate with fellow architects', 'sample content for call to action', 'twentytwentyfour' ); ?></li>
+				<li><?php echo esc_html_x( 'Collaborate with fellow architects', 'A general list item.', 'twentytwentyfour' ); ?></li>
 				<!-- /wp:list-item -->
 
 				<!-- wp:list-item -->
-				<li><?php echo esc_html_x( 'Showcase your projects', 'sample content for call to action', 'twentytwentyfour' ); ?></li>
+				<li><?php echo esc_html_x( 'Showcase your projects', 'A general list item.', 'twentytwentyfour' ); ?></li>
 				<!-- /wp:list-item -->
 
 				<!-- wp:list-item -->
-				<li><?php echo esc_html_x( 'Experience the world of architecture like never before', 'sample content for call to action', 'twentytwentyfour' ); ?></li>
+				<li><?php echo esc_html_x( 'Experience the world of architecture like never before', 'A general list item.', 'twentytwentyfour' ); ?></li>
 				<!-- /wp:list-item -->
 			</ul>
 			<!-- /wp:list -->

--- a/style.css
+++ b/style.css
@@ -71,3 +71,15 @@ a {
 .is-style-pill a:hover {
 	background:#eee;
 }
+
+/*
+ * Styles for the custom checkmark list block style
+ * https://github.com/WordPress/gutenberg/issues/51480
+ */
+ul.is-style-checkmark-list {
+	list-style-type: "\2713";
+}
+
+ul.is-style-checkmark-list li {
+	padding-inline-start: 1ch;
+}


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Alternative to https://github.com/WordPress/twentytwentyfour/pull/150
Closes https://github.com/WordPress/twentytwentyfour/issues/46

I made this PR because rebasing the older one was a little bit of a mess

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

<img width="1363" alt="Screenshot 2023-09-15 at 10 51 15" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/3e69fd5f-1cb8-4316-a54e-77a9afbad18a">
<img width="1384" alt="Screenshot 2023-09-15 at 10 51 10" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/450e671a-bedf-43c4-b393-543e79ae80cf">


**Testing Instructions**

<!-- Provide steps for testing -->
<!-- 1. Activate the theme. -->
<!-- 2. Visit the archives page. -->
<!-- 3. etc. -->
Insert a list block and toggle the checkmarks style
