### PR TITLE
Fix home page in the editor

### DIFF
--- a/patterns/page-01-business-home.php
+++ b/patterns/page-01-business-home.php
@@ -5,7 +5,6 @@
  * Categories: about
  * Keywords: page, starter
  * Block Types: core/post-content
- * Post Types: page
  * Viewport width: 1400
  */
 ?>


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Closes https://github.com/WordPress/twentytwentyfour/pull/370

This removes the Post Type attr from the home pattern so that it shows in the site editor. Sadly this makes the pattern visible in the inserter for posts too, but unless there's a fix in the editor before 6.4 we are stuck with this solution or a broken experience for the theme


**Testing Instructions**

<!-- Provide steps for testing -->
<!-- 1. Activate the theme. -->
<!-- 2. Visit the archives page. -->
<!-- 3. etc. -->

Without this PR you won't see the home page pattern in the site editor. With this PR applied you should see the home as expected.