### PR TITLE
Allow the home pattern to load in the site editor

### DIFF
--- a/patterns/page-01-business-home.php
+++ b/patterns/page-01-business-home.php
@@ -5,7 +5,7 @@
  * Categories: about
  * Keywords: page, starter
  * Block Types: core/post-content
- * Post Types: page
+ * Post Types: page, wp_template
  * Viewport width: 1400
  */
 ?>

--- a/patterns/page-02-business-about.php
+++ b/patterns/page-02-business-about.php
@@ -5,7 +5,7 @@
  * Categories: about
  * Keywords: page, starter
  * Block Types: core/post-content
- * Post Types: page
+ * Post Types: page, wp_template
  * Viewport width: 1400
  */
 ?>

--- a/patterns/page-03-portfolio-overview.php
+++ b/patterns/page-03-portfolio-overview.php
@@ -5,7 +5,7 @@
  * Categories: about
  * Keywords: page, starter
  * Block Types: core/post-content
- * Post Types: page
+ * Post Types: page, wp_template
  * Viewport width: 1400
  */
 ?>

--- a/patterns/page-04-newsletter-landing.php
+++ b/patterns/page-04-newsletter-landing.php
@@ -5,7 +5,7 @@
  * Categories: call-to-action
  * Keywords: page, starter
  * Block Types: core/post-content
- * Post Types: page
+ * Post Types: page, wp_template
  * Viewport width: 1100
  */
 

--- a/patterns/page-05-portfolio-home.php
+++ b/patterns/page-05-portfolio-home.php
@@ -5,7 +5,7 @@
  * Categories: portfolio
  * Keywords: page, starter
  * Block Types: core/post-content
- * Post Types: page
+ * Post Types: page, wp_template
  * Viewport width: 1400
  */
 ?>


### PR DESCRIPTION
**Description**
Adds the wp_template type to the home pattern to allow it to be loaded in the site editor, as suggested in https://github.com/WordPress/gutenberg/pull/41842#issuecomment-1239547826.

**Screenshots**
<img width="1416" alt="Screenshot 2023-09-15 at 12 30 32" src="https://github.com/WordPress/twentytwentyfour/assets/275961/5209f9a9-5ef5-4ddc-9ac8-f6b9d9dcb6a1">

<!-- Add screenshots of the change, if applicable -->

**Testing Instructions**
Open the site editor and check that you can see the home page template.

**Contributors**

<!-- Please ensure anyone who contributed on linked issues and within this pull request have _AT LEAST_ their GitHub Username listed in the `CONTRIBUTORS.md` file as part of this PR. -->
