### PR TITLE
Fix: Indent with Tabs

### DIFF
--- a/style.css
+++ b/style.css
@@ -46,7 +46,7 @@ a {
 }
 
 .is-style-arrow-icon-details summary {
-    list-style-type: '\2193\00a0\00a0\00a0';
+	list-style-type: '\2193\00a0\00a0\00a0';
 }
 
 .is-style-arrow-icon-details[open] > summary {


### PR DESCRIPTION
**Description**
Fixes the phpcs error:
`Tabs must be used to indent lines; spaces are not allowed`