### PR TITLE
Use `esc_attr__` instead of `esc_attr` to make strings translatable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ WordPress block patterns should be [internationalized](https://developer.wordpre
 
 `esc_html__()`: Similar to `esc_html_x()`, use this function for translating and escaping HTML-embedded text. It's a simpler version when context-specific translations are not needed.
 
-`esc_attr()` and `esc_attr_x()`: Use this function to escape and sanitize text meant for HTML attributes, such as image source URLs or link targets. It helps prevent security vulnerabilities by ensuring that user inputs are safe for use in attributes.
+`esc_attr__()` and `esc_attr_x()`: Use this function to escape and sanitize text meant for HTML attributes, such as image source URLs or link targets. It helps prevent security vulnerabilities by ensuring that user inputs are safe for use in attributes.
 
 These functions enhance security and support localization efforts in WordPress block patterns, ensuring that text is safe and can be easily translated.
 

--- a/patterns/clients.php
+++ b/patterns/clients.php
@@ -18,23 +18,23 @@
 <!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|30","padding":{"right":"0","left":"0","top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
 <div class="wp-block-group alignwide" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 <!-- wp:image {"width":140,"height":65,"scale":"contain","sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/client-logo-1.webp" alt="<?php echo esc_attr( 'Logo of client 1', 'twentytwentyfour' ); ?>" style="object-fit:contain;width:140px;height:65px" width="140" height="65"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/client-logo-1.webp" alt="<?php echo esc_attr__( 'Logo of client 1', 'twentytwentyfour' ); ?>" style="object-fit:contain;width:140px;height:65px" width="140" height="65"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":110,"height":60,"scale":"contain","sizeSlug":"full","linkDestination":"none","className":"size-full"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/client-logo-2.webp" alt="<?php echo esc_attr( 'Logo of client 2', 'twentytwentyfour' ); ?>" style="object-fit:contain;width:110px;height:60px" width="110" height="60"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/client-logo-2.webp" alt="<?php echo esc_attr__( 'Logo of client 2', 'twentytwentyfour' ); ?>" style="object-fit:contain;width:110px;height:60px" width="110" height="60"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":150,"height":72,"scale":"contain","sizeSlug":"full","linkDestination":"none","className":"size-full"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/client-logo-3.webp" alt="<?php echo esc_attr( 'Logo of client 3', 'twentytwentyfour' ); ?>" style="object-fit:contain;width:150px;height:72px" width="150" height="72"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/client-logo-3.webp" alt="<?php echo esc_attr__( 'Logo of client 3', 'twentytwentyfour' ); ?>" style="object-fit:contain;width:150px;height:72px" width="150" height="72"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":160,"height":44,"scale":"contain","sizeSlug":"full","linkDestination":"none","className":"size-full"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/client-logo-4.webp" alt="<?php echo esc_attr( 'Logo of client 4', 'twentytwentyfour' ); ?>" style="object-fit:contain;width:160px;height:44px" width="160" height="44"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/client-logo-4.webp" alt="<?php echo esc_attr__( 'Logo of client 4', 'twentytwentyfour' ); ?>" style="object-fit:contain;width:160px;height:44px" width="160" height="44"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":184,"height":51,"scale":"contain","sizeSlug":"full","linkDestination":"none","className":"size-full"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/client-logo-5.webp" alt="<?php echo esc_attr( 'Logo of client 5', 'twentytwentyfour' ); ?>" style="object-fit:contain;width:184px;height:51px" width="184" height="51"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/client-logo-5.webp" alt="<?php echo esc_attr__( 'Logo of client 5', 'twentytwentyfour' ); ?>" style="object-fit:contain;width:184px;height:51px" width="184" height="51"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/patterns/features-with-images.php
+++ b/patterns/features-with-images.php
@@ -44,7 +44,7 @@
 
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
-<figure class="wp-block-image size-large is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/business-app.webp" alt="<?php echo esc_attr( 'Woman taking picture of a building.', 'twentytwentyfour' ); ?>"/></figure>
+<figure class="wp-block-image size-large is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/business-app.webp" alt="<?php echo esc_attr__( 'Woman taking picture of a building.', 'twentytwentyfour' ); ?>"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
@@ -56,7 +56,7 @@
 <!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|80"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
-<figure class="wp-block-image size-large is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/home.webp" alt="<?php echo esc_attr( 'Windows of a building.', 'twentytwentyfour' ); ?>"/></figure>
+<figure class="wp-block-image size-large is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/home.webp" alt="<?php echo esc_attr__( 'Windows of a building.', 'twentytwentyfour' ); ?>"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 

--- a/patterns/hero.php
+++ b/patterns/hero.php
@@ -36,6 +36,6 @@
 <!-- /wp:group -->
 
 <!-- wp:image {"align":"wide","sizeSlug":"full","linkDestination":"none","className":"is-style-rounded"} -->
-<figure class="wp-block-image alignwide size-full is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/business-hero.webp" alt="<?php echo esc_attr( 'A skyscraper building.', 'twentytwentyfour' ); ?>"/></figure>
+<figure class="wp-block-image alignwide size-full is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/business-hero.webp" alt="<?php echo esc_attr__( 'A skyscraper building.', 'twentytwentyfour' ); ?>"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->

--- a/patterns/left-aligned-cta-image.php
+++ b/patterns/left-aligned-cta-image.php
@@ -54,7 +54,7 @@
 		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:574px">
 			<!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
 			<figure class="wp-block-image size-large is-style-rounded">
-				<img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/left-aligned-cta.webp" alt="<?php echo esc_attr( 'An abstract Pattern Image', 'twentytwentyfour' ); ?>" />
+				<img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/left-aligned-cta.webp" alt="<?php echo esc_attr__( 'An abstract Pattern Image', 'twentytwentyfour' ); ?>" />
 			</figure>
 			<!-- /wp:image -->
 		</div>

--- a/patterns/page-04-newsletter-landing.php
+++ b/patterns/page-04-newsletter-landing.php
@@ -13,7 +13,7 @@
 
 <!-- wp:cover {"overlayColor":"accent-3","minHeight":100,"minHeightUnit":"vh","isDark":false,"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-cover alignfull is-light" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50);min-height:100vh"><span aria-hidden="true" class="wp-block-cover__background has-accent-3-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:image {"align":"center","width":"45px","height":"49px","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-message.webp" alt="<?php echo esc_attr( 'Envelope icon', 'twentytwentyfour' ); ?>" style="object-fit:cover;width:45px;height:49px"/></figure>
+<figure class="wp-block-image aligncenter size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-message.webp" alt="<?php echo esc_attr__( 'Envelope icon', 'twentytwentyfour' ); ?>" style="object-fit:cover;width:45px;height:49px"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:spacer {"height":"var:preset|spacing|10"} -->

--- a/patterns/project-description.php
+++ b/patterns/project-description.php
@@ -30,6 +30,6 @@
 <!-- /wp:spacer -->
 
 <!-- wp:image {"align":"wide","sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
-<figure class="wp-block-image alignwide size-large is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/tt4_projectoverview.jpg" alt="<?php echo esc_attr( 'An women walking in the stair.', 'twentytwentyfour' ); ?>"/></figure>
+<figure class="wp-block-image alignwide size-large is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/tt4_projectoverview.jpg" alt="<?php echo esc_attr__( 'An women walking in the stair.', 'twentytwentyfour' ); ?>"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->

--- a/patterns/rsvp.php
+++ b/patterns/rsvp.php
@@ -33,7 +33,7 @@
 
 <!-- wp:column {"verticalAlignment":"top","width":"50%"} -->
 <div class="wp-block-column is-vertically-aligned-top" style="flex-basis:50%"><!-- wp:image {"aspectRatio":"3/4","scale":"cover","sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
-<figure class="wp-block-image size-large is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/rsvp.webp" alt="<?php echo esc_attr( 'An abstract pattern image', 'twentytwentyfour' ); ?>" style="aspect-ratio:3/4;object-fit:cover"/></figure>
+<figure class="wp-block-image size-large is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/rsvp.webp" alt="<?php echo esc_attr__( 'An abstract pattern image', 'twentytwentyfour' ); ?>" style="aspect-ratio:3/4;object-fit:cover"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>

--- a/patterns/services-cta.php
+++ b/patterns/services-cta.php
@@ -11,7 +11,7 @@
 <div class="wp-block-group alignfull has-contrast-3-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|40","left":"var:preset|spacing|50"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center","width":"60%"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:60%"><!-- wp:image {"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|black-and-white"}},"className":"is-style-rounded"} -->
-<figure class="wp-block-image size-full is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/services.webp" alt="<?php echo esc_attr( 'A man holding some paper', 'twentytwentyfour' ); ?>" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/services.webp" alt="<?php echo esc_attr__( 'A man holding some paper', 'twentytwentyfour' ); ?>" style="aspect-ratio:4/3;object-fit:cover"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 

--- a/patterns/team.php
+++ b/patterns/team.php
@@ -20,7 +20,7 @@
 <div class="wp-block-columns" style="padding-right:0;padding-left:0"><!-- wp:column {"layout":{"type":"default"}} -->
 <div class="wp-block-column"><!-- wp:group {"layout":{"type":"default"}} -->
 <div class="wp-block-group"><!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-rounded"} -->
-<figure class="wp-block-image size-full is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/team-member-1.webp" alt="<?php echo esc_attr( 'Picture of woman tying her hair', 'twentytwentyfour' ); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/team-member-1.webp" alt="<?php echo esc_attr__( 'Picture of woman tying her hair', 'twentytwentyfour' ); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|0"}},"layout":{"type":"constrained"}} -->
@@ -38,7 +38,7 @@
 <!-- wp:column {"layout":{"type":"default"}} -->
 <div class="wp-block-column"><!-- wp:group {"layout":{"type":"default"}} -->
 <div class="wp-block-group"><!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-rounded"} -->
-<figure class="wp-block-image size-full is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/team-member-2.webp" alt="<?php echo esc_attr( 'Portrait of a man looking ahead', 'twentytwentyfour' ); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/team-member-2.webp" alt="<?php echo esc_attr__( 'Portrait of a man looking ahead', 'twentytwentyfour' ); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|0"}},"layout":{"type":"constrained"}} -->
@@ -56,7 +56,7 @@
 <!-- wp:column {"layout":{"type":"default"}} -->
 <div class="wp-block-column"><!-- wp:group {"layout":{"type":"default"}} -->
 <div class="wp-block-group"><!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-rounded"} -->
-<figure class="wp-block-image size-full is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/team-member-3.webp" alt="<?php echo esc_attr( 'Portrait of a woman looking to the side', 'twentytwentyfour' ); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/team-member-3.webp" alt="<?php echo esc_attr__( 'Portrait of a woman looking to the side', 'twentytwentyfour' ); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|0"}},"layout":{"type":"constrained"}} -->
@@ -74,7 +74,7 @@
 <!-- wp:column {"layout":{"type":"default"}} -->
 <div class="wp-block-column"><!-- wp:group {"layout":{"type":"default"}} -->
 <div class="wp-block-group"><!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-rounded"} -->
-<figure class="wp-block-image size-full is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/team-member-4.webp" alt="<?php echo esc_attr( 'Picture of a man with a hat wearing a backpack', 'twentytwentyfour' ); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/team-member-4.webp" alt="<?php echo esc_attr__( 'Picture of a man with a hat wearing a backpack', 'twentytwentyfour' ); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|0"}},"layout":{"type":"constrained"}} -->

--- a/patterns/testimonial.php
+++ b/patterns/testimonial.php
@@ -14,7 +14,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"align":"center","width":64,"height":64,"scale":"cover","sizeSlug":"thumbnail","linkDestination":"none","style":{"border":{"radius":"999px"}},"className":"is-style-rounded"} -->
-<figure class="wp-block-image aligncenter size-thumbnail is-resized has-custom-border is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/testimonial-avatar.webp" alt="<?php echo esc_attr( 'Portrait of a woman looking down Side', 'twentytwentyfour' ); ?>" style="border-radius:999px;object-fit:cover;width:64px;height:64px" width="64" height="64"/></figure>
+<figure class="wp-block-image aligncenter size-thumbnail is-resized has-custom-border is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/testimonial-avatar.webp" alt="<?php echo esc_attr__( 'Portrait of a woman looking down Side', 'twentytwentyfour' ); ?>" style="border-radius:999px;object-fit:cover;width:64px;height:64px" width="64" height="64"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph {"align":"center"} -->


### PR DESCRIPTION
**Description**
This pull request changes the function calls from `esc_attr` to `esc_attr__` to make strings translatable.

`esc_attr( string $text )`: Escapes for HTML attributes and only accepts one parameter, the $text.

`esc_attr__( string $text, string $domain = 'default' )`: Retrieves the translation of $text and escapes it for safe use in an attribute.
