### PR TITLE
Remove the H1 from the posts pattern

### DIFF
--- a/patterns/posts.php
+++ b/patterns/posts.php
@@ -28,7 +28,7 @@
 <!-- /wp:spacer -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:post-title {"level":2,"isLink":true,"fontSize":"x-large"} /-->
+<div class="wp-block-group"><!-- wp:post-title {"level":3,"isLink":true,"fontSize":"x-large"} /-->
 
 <!-- wp:post-excerpt {"excerptLength":35} /-->
 

--- a/patterns/posts.php
+++ b/patterns/posts.php
@@ -9,8 +9,8 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-<!-- wp:heading {"level":1,"align":"wide","style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"0"}}},"fontSize":"x-large"} -->
-<h1 class="wp-block-heading alignwide has-x-large-font-size" style="margin-top:0;line-height:1">Watch, Read, Listen</h1>
+<!-- wp:heading {"align":"wide","style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"0"}}},"fontSize":"x-large"} -->
+<h2 class="wp-block-heading alignwide has-x-large-font-size" style="margin-top:0;line-height:1">Watch, Read, Listen</h2>
 <!-- /wp:heading -->
 
 <!-- wp:spacer {"height":"var:preset|spacing|10","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->


### PR DESCRIPTION
**Description**
Since the posts pattern will no longer be used on the default index template, the "Watch, Read, Listen" heading above the posts no longer needs to be an H1. Changing it to an H2 removes the duplicate H1 headings from the home template.
