### PR TITLE
Fixed Separator Width Issue in Sidebar

### DIFF
--- a/patterns/hidden-sidebar-writer.php
+++ b/patterns/hidden-sidebar-writer.php
@@ -21,7 +21,7 @@
 <!-- /wp:group -->
 
 <!-- wp:separator {"backgroundColor":"base-3"} -->
-<hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-custom-borders-background-color has-background"/>
+<hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-custom-borders-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 
 <!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
@@ -53,7 +53,7 @@
 <!-- /wp:query -->
 
 <!-- wp:separator {"backgroundColor":"base-3"} -->
-<hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-custom-borders-background-color has-background"/>
+<hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-custom-borders-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"1.6rem"}},"layout":{"type":"flex","orientation":"vertical"}} -->

--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -21,7 +21,7 @@
 <!-- /wp:group -->
 
 <!-- wp:separator {"backgroundColor":"base-3"} -->
-<hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-custom-borders-background-color has-background"/>
+<hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-custom-borders-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 
 <!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
@@ -53,7 +53,7 @@
 <!-- /wp:query -->
 
 <!-- wp:separator {"backgroundColor":"base-3"} -->
-<hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-custom-borders-background-color has-background"/>
+<hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-custom-borders-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 
 <!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->


### PR DESCRIPTION
## **Fixed Separator Width Issue in Sidebar  (Used is-style-wide for separator)**

**Before:** 
![before-separator](https://github.com/WordPress/twentytwentyfour/assets/22027190/eb556f8d-fad4-474f-a73f-401b273c6210)

**After:** 
![after-separator](https://github.com/WordPress/twentytwentyfour/assets/22027190/3d861ddf-8b5f-4838-b60d-62c2209189ae)


