### PR TITLE
Add rust theme variation

### DIFF
--- a/styles/rust.json
+++ b/styles/rust.json
@@ -1,0 +1,95 @@
+{
+	"version": 2,
+	"title": "Rust",
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"settings": {
+		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#A62B0C",
+						"#F3F0E7"
+					],
+					"slug": "duotone-1",
+					"name": "Dark rust to beige"
+				}
+			],
+			"gradients": [
+				{
+					"slug": "gradient-1",
+					"gradient": "linear-gradient(to bottom, #A62A0C5C 0%, #F3F0E7 100%)",
+					"name": "Vertical rust to beige"
+				},
+				{
+					"slug": "gradient-7",
+					"gradient": "linear-gradient(to bottom, #A62A0C5C 50%, #F3F0E7 50%)",
+					"name": "Vertical hard rust to beige"
+				}
+			],
+			"palette": [
+				{
+					"color": "#F3F0E7",
+					"name": "Base",
+					"slug": "base"
+				},
+				{
+					"color": "#EAE4D7",
+					"name": "Base / 2",
+					"slug": "base-2"
+				},
+				{
+					"color": "#A62B0C",
+					"name": "Contrast",
+					"slug": "contrast"
+				}
+			]
+		},
+		"layout": {
+			"contentSize": "620px",
+			"wideSize": "90vw"
+		},
+		"typography": {
+			"fontSizes": [
+				{
+					"fluid": false,
+					"name": "Small",
+					"size": "1rem",
+					"slug": "small"
+				},
+				{
+					"fluid": false,
+					"name": "Medium",
+					"size": "1.2rem",
+					"slug": "medium"
+				},
+				{
+					"fluid": {
+						"min": "1.777rem",
+						"max": "2.3rem"
+					},
+					"name": "Large",
+					"size": "2.3rem",
+					"slug": "large"
+				},
+				{
+					"fluid": {
+						"min": "2.3rem",
+						"max": "3.1rem"
+					},
+					"name": "Extra Large",
+					"size": "2.369rem",
+					"slug": "x-large"
+				},
+				{
+					"fluid": {
+						"min": "3.1rem",
+						"max": "4.2rem"
+					},
+					"name": "Extra Extra Large",
+					"size": "4.2rem",
+					"slug": "xx-large"
+				}
+			]
+		}
+	}
+}

--- a/styles/rust.json
+++ b/styles/rust.json
@@ -59,7 +59,7 @@
 				{
 					"fluid": false,
 					"name": "Medium",
-					"size": "1.2rem",
+					"size": "1.15rem",
 					"slug": "medium"
 				},
 				{


### PR DESCRIPTION
**Description**
Seeing how a variation without a lot of accent colors will look and feel. 

One thing that stands out to me is how tied the images are to the default variation. An idea we can potentially try is to have a duotone preset on images within patterns that does nothing on the default variation, but alternate variations could style. 

But I don't think this is a blocker to this (and subsequent variations). Rather something we can explore. 

For example, this pattern has a black and white duotone (`dutone-1`) applied, and the Rust variation here makes duotone-1 rust to beige. That makes this image fit in better with the new variation, without having to apply the duotone to the image block globally (which I don't think is a good idea as it is disorienting having it auto-applied). 

<img width="284" alt="CleanShot 2023-09-17 at 21 28 55" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/14c3a1aa-ec10-4d5a-b6c5-b80a99631bcc">
<img width="288" alt="CleanShot 2023-09-17 at 21 28 27" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/6aa2e51e-5829-4055-ae3f-d3cf4e67a4d6">



### Pattern visuals

<img width="299" alt="CleanShot 2023-09-17 at 21 24 02" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/76721335-30d1-4459-a6d5-ea2bc73f50c0">
<img width="296" alt="CleanShot 2023-09-17 at 21 26 20" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/b00e978d-710f-4c87-99c9-4ff7b44b4ff1">
