### PR TITLE
Update search form styling

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -459,6 +459,9 @@
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
+			"core/post-comments-form": {
+				"css": "& textarea, input{border-radius:.33rem}"
+			},
 			"core/comments-pagination": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
@@ -506,6 +509,9 @@
 						"left": "var(--wp--preset--spacing--10)"
 					}
 				}
+			},
+			"core/loginout": {
+				"css": "& input{border-radius:.33rem;padding:calc(0.667em + 2px);border:1px solid #949494;}"
 			},
 			"core/navigation": {
 				"elements": {

--- a/theme.json
+++ b/theme.json
@@ -716,9 +716,16 @@
 				}
 			},
 			"core/search": {
+				"css": "& .wp-block-search__input{border-radius:.33rem}",
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"fontWeight": "600"
+					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				"elements": {
+					"button": {
+						"border": {
+							"radius": { "ref": "styles.elements.button.border.radius" }
+						}
+					}
 				}
 			},
 			"core/separator": {


### PR DESCRIPTION
**Description**
Updates the default border radius for the button and input field.
Removes the font weight.

Closes https://github.com/WordPress/twentytwentyfour/issues/389

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

**Testing Instructions**
Add a search block with different settings to confirm that the design is correct ( see the issue ).

In the block's sidebar settings, adjust the border radius and confirm that the user's settings still overrides the default.

