### PR TITLE
Add page with sidebar

### DIFF
--- a/templates/page-with-sidebar.html
+++ b/templates/page-with-sidebar.html
@@ -4,10 +4,11 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"0vh","bottom":"0vh"},"padding":{"top":"10vh","bottom":"8vh"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="margin-top:0vh;margin-bottom:0vh;padding-top:10vh;padding-bottom:8vh">
-	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"1rem","left":"1rem"}}}} -->
-	<div class="wp-block-columns alignwide">
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group">
+
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"1rem","left":"1rem"},"padding":{"top":"var:preset|spacing|50"},"margin":{"bottom":"var:preset|spacing|40"}}}} -->
+	<div class="wp-block-columns alignwide" style="margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--50)">
 		<!-- wp:column {"width":"10%"} -->
 		<div class="wp-block-column" style="flex-basis:10%"></div>
 		<!-- /wp:column -->

--- a/templates/page-with-sidebar.html
+++ b/templates/page-with-sidebar.html
@@ -1,0 +1,52 @@
+<!-- wp:group {"style":{"position":{"type":"sticky","top":"0px"}},"layout":{"type":"default"}} -->
+<div class="wp-block-group">
+	<!-- wp:template-part {"slug":"header"} /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"0vh","bottom":"0vh"},"padding":{"top":"10vh","bottom":"8vh"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="margin-top:0vh;margin-bottom:0vh;padding-top:10vh;padding-bottom:8vh">
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"1rem","left":"1rem"}}}} -->
+	<div class="wp-block-columns alignwide">
+		<!-- wp:column {"width":"10%"} -->
+		<div class="wp-block-column" style="flex-basis:10%"></div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"width":"60%"} -->
+		<div class="wp-block-column" style="flex-basis:60%">
+			<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":false},"layout":{"type":"constrained"}} -->
+			<main class="wp-block-group">
+				<!-- wp:post-title {"level":1,"fontSize":"x-large"} /-->
+
+				<!-- wp:spacer {"height":"var:preset|spacing|30","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+				<div style="margin-top:0;margin-bottom:0;height:var(--wp--preset--spacing--30)" aria-hidden="true"
+					class="wp-block-spacer"></div>
+				<!-- /wp:spacer -->
+
+				<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
+
+				<!-- wp:post-content {"lock":{"move":false,"remove":true},"layout":{"type":"constrained"}} /-->
+			</main>
+			<!-- /wp:group -->
+	</div>
+	<!-- /wp:column -->
+
+	<!-- wp:column {"width":"10%"} -->
+	<div class="wp-block-column" style="flex-basis:10%"></div>
+	<!-- /wp:column -->
+
+	<!-- wp:column {"width":"30%"} -->
+	<div class="wp-block-column" style="flex-basis:30%">
+		<!-- wp:template-part {"slug":"sidebar"} /-->
+	</div>
+	<!-- /wp:column -->
+
+	<!-- wp:column {"width":"10%"} -->
+	<div class="wp-block-column" style="flex-basis:10%"></div>
+	<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer"} /-->

--- a/theme.json
+++ b/theme.json
@@ -960,6 +960,13 @@
 			"title": "Page No Title"
 		},
 		{
+			"name": "page-with-sidebar",
+			"postTypes": [
+				"page"
+			],
+			"title": "Page With Sidebar"
+		},
+		{
 			"name": "page-writer",
 			"postTypes": [
 				"page"


### PR DESCRIPTION
**Description**

Re-adds the page with sidebar template.
This template and the sidebar pattern will need several iterations to spacing and to fix accessibility issues.

Only the "writer" design has a page with sidebar so I am not sure that this is correct.
There is a page template with sidebar listed here: https://github.com/WordPress/twentytwentyfour/issues/9

Figma: https://www.figma.com/file/AlYr03vh4dVimwYwQkTdf6/Twenty-Twenty-Four?node-id=511%3A1757&mode=dev

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

**Testing Instructions**

Select or create a new page.
In the block editor, in the Page panel, select template and choose "Page with Sidebar"
Save.
View the page on the front.

