### PR TITLE
Fix Writer Home Page template in the site editor

### DIFF
--- a/patterns/page-06-writer-home.php
+++ b/patterns/page-06-writer-home.php
@@ -5,7 +5,7 @@
  * Categories: portfolio
  * Keywords: page, starter
  * Block Types: core/post-content
- * Post Types: page
+ * Post Types: page, wp_template
  * Viewport width: 1400
  */
 ?>


### PR DESCRIPTION
**Description**
Like all the other page templates, the writer page template needs a wp_template post type so that it appears in the site editor.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

**Testing Instructions**
Update home.html to point to this pattern:

```
<!-- wp:group {"style":{"position":{"type":"sticky","top":"0px"}},"layout":{"type":"default"}} -->
	<div class="wp-block-group">
		<!-- wp:template-part {"slug":"header"} /-->
	</div>
<!-- /wp:group -->

<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0","margin":{"top":"0"}}},"layout":{"type":"default"}} -->
<main class="wp-block-group" style="margin-top:0">
	<!-- wp:pattern {"slug":"twentytwentyfour/page-writer-home"} /-->
</main>
<!-- /wp:group -->

<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer"} /-->
```

Check that the content still loads in the editor.

**Contributors**

<!-- Please ensure anyone who contributed on linked issues and within this pull request have _AT LEAST_ their GitHub Username listed in the `CONTRIBUTORS.md` file as part of this PR. -->
