### PR TITLE
Fix broken writer home template pattern

### DIFF
--- a/patterns/page-06-writer-home.php
+++ b/patterns/page-06-writer-home.php
@@ -66,10 +66,7 @@
 
 <!-- wp:column {"width":"30%"} -->
 <div class="wp-block-column" style="flex-basis:30%">
-
-
-<!-- wp:pattern {"slug":"twentytwentyfour/sidebar"} /-->
-
+<!-- wp:template-part {"slug":"sidebar","theme":"twentytwentyfour"} /-->
 </div>
 <!-- /wp:column -->
 

--- a/patterns/page-06-writer-home.php
+++ b/patterns/page-06-writer-home.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Title: Writer Home
+ * Title: Writer Home Page
  * Slug: twentytwentyfour/page-writer-home
- * Categories: portfolio
+ * Categories: text, page
  * Keywords: page, starter
  * Block Types: core/post-content
  * Post Types: page, wp_template
@@ -12,8 +12,8 @@
 
 <!-- wp:pattern {"slug":"twentytwentyfour/text-centered-title"}	/-->
 
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"1rem","left":"1rem"}}}} -->
+<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"1rem","left":"1rem"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"10%"} -->
 <div class="wp-block-column" style="flex-basis:10%"></div>
 <!-- /wp:column -->
@@ -67,6 +67,7 @@
 <!-- wp:column {"width":"30%"} -->
 <div class="wp-block-column" style="flex-basis:30%">
 
+
 <!-- wp:pattern {"slug":"twentytwentyfour/sidebar"} /-->
 
 </div>
@@ -79,4 +80,3 @@
 <!-- /wp:group -->
 
 <!-- wp:pattern {"slug":"twentytwentyfour/cta"}	/-->
-


### PR DESCRIPTION
**Description**

Makes the template the proper width and takes it out of the 'portfolio' category. Also uses the sidebar template part, instead of the hidden sidebar pattern directly (#408). 

### Before
<img width="1179" alt="CleanShot 2023-09-18 at 13 32 37" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/e534268a-ea8f-4f8a-9431-69a17c91d033">

### After
<img width="1176" alt="CleanShot 2023-09-18 at 13 33 09" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/5f52ec61-a028-42a4-ae1d-66df6d371592">

