### PR TITLE
Fix sidebar display in site editor + make it more consistent

### DIFF
--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -44,7 +44,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size">by</p>
+<p class="has-small-font-size"><?php echo esc_html__( 'by', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:post-author-name {"isLink":true} /-->

--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -6,38 +6,56 @@
  * Inserter: no
  */
 ?>
-<!-- wp:group {"style":{"spacing":{"blockGap":"2.5rem"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-<div class="wp-block-group"><!-- wp:group {"layout":{"type":"constrained"}} -->
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained","contentSize":"420px"}} -->
+<div class="wp-block-group"><!-- wp:spacer {"height":"var:preset|spacing|10"} -->
+<div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:avatar {"size":80,"style":{"border":{"radius":"16px"}}} /-->
 
 <!-- wp:heading {"style":{"typography":{"fontSize":"1.4rem"}}} -->
 <h2 class="wp-block-heading" style="font-size:1.4rem"><?php echo esc_html__( 'About the author', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:post-author-biography {"fontSize":"small"} /-->
-</div>
+<!-- wp:post-author-biography {"fontSize":"small"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:separator {"backgroundColor":"base-3","className":"is-style-wide"} -->
 <hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-base-3-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 
-<!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
-<h2 class="wp-block-heading" style="font-size:1.6rem"><?php echo esc_html__( 'Latest Posts', 'twentytwentyfour' ); ?></h2>
+<!-- wp:heading {"style":{"typography":{"fontSize":"1.4rem"}}} -->
+<h2 class="wp-block-heading" style="font-size:1.4rem"><?php echo esc_html__( 'Latest Posts', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+<!-- wp:query {"queryId":5,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
-<!-- wp:group {"style":{"spacing":{"blockGap":"0.5rem"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<!-- wp:group {"style":{"spacing":{"blockGap":"2px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:post-title {"isLink":true,"fontSize":"medium"} /-->
 
-<!-- wp:pattern {"slug":"twentytwentyfour/post-meta"} /-->
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"0.3em"}},"layout":{"type":"flex","justifyContent":"left"}} -->
+<div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y","isLink":true} /-->
 
-</div>
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
+<p class="has-contrast-2-color has-text-color has-link-color">—</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"fontSize":"small"} -->
+<p class="has-small-font-size">by</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:post-author-name {"isLink":true} /-->
+
+<!-- wp:post-terms {"term":"category","prefix":"in "} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:spacer {"height":"30px"} -->
-<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
+<div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 <!-- /wp:post-template --></div>
 <!-- /wp:query -->
@@ -47,10 +65,8 @@
 <!-- /wp:separator -->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group">
-
-<!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
-<h2 class="wp-block-heading" style="font-size:1.6rem"><?php echo esc_html__( 'Useful links', 'twentytwentyfour' ); ?></h2>
+<div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontSize":"1.4rem"}}} -->
+<h2 class="wp-block-heading" style="font-size:1.4rem"><?php echo esc_html__( 'Useful links', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"fontSize":"small"} -->
@@ -60,10 +76,10 @@
 <!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400","textDecoration":"underline"}},"fontSize":"small"} -->
 <!-- wp:navigation-link {"label":"<?php echo esc_html__( 'Latest inflation report', 'twentytwentyfour' ); ?>","url":"#"} /-->
 <!-- wp:navigation-link {"label":"<?php echo esc_html__( 'Financial apps for families', 'twentytwentyfour' ); ?>","url":"#"} /-->
-<!-- /wp:navigation -->
-
-</div>
+<!-- /wp:navigation --></div>
 <!-- /wp:group -->
 
-</div>
+<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
+<div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div>
 <!-- /wp:group -->

--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -8,15 +8,17 @@
 ?>
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained","contentSize":"420px"}} -->
-<div class="wp-block-group"><!-- wp:spacer {"height":"var:preset|spacing|10"} -->
+<div class="wp-block-group">
+
+<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
 <div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:avatar {"size":80,"style":{"border":{"radius":"16px"}}} /-->
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="margin-top:0;margin-bottom:0"><!-- wp:avatar {"size":80,"style":{"border":{"radius":"16px"}}} /-->
 
-<!-- wp:heading {"style":{"typography":{"fontSize":"1.4rem"}}} -->
-<h2 class="wp-block-heading" style="font-size:1.4rem"><?php echo esc_html__( 'About the author', 'twentytwentyfour' ); ?></h2>
+<!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
+<h2 class="wp-block-heading" style="font-size:1.6rem"><?php echo esc_html__( 'About the author', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:post-author-biography {"fontSize":"small"} /--></div>
@@ -26,52 +28,55 @@
 <hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-base-3-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 
-<!-- wp:heading {"style":{"typography":{"fontSize":"1.4rem"}}} -->
-<h2 class="wp-block-heading" style="font-size:1.4rem"><?php echo esc_html__( 'Latest Posts', 'twentytwentyfour' ); ?></h2>
-<!-- /wp:heading -->
-
-<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
-<div class="wp-block-query"><!-- wp:post-template -->
-<!-- wp:group {"style":{"spacing":{"blockGap":"2px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"fontSize":"medium"} /-->
-
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"0.3em"}},"layout":{"type":"flex","justifyContent":"left"}} -->
-<div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y","isLink":true} /-->
+<div class="wp-block-group">
+	<!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
+	<h2 class="wp-block-heading" style="font-size:1.6rem"><?php echo esc_html__( 'Latest Posts', 'twentytwentyfour' ); ?></h2>
+	<!-- /wp:heading -->
 
-<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
-<p class="has-contrast-2-color has-text-color has-link-color">—</p>
-<!-- /wp:paragraph -->
+	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+	<div class="wp-block-query"><!-- wp:post-template -->
+	<!-- wp:group {"style":{"spacing":{"blockGap":"2px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+	<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"fontSize":"medium"} /-->
 
-<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size"><?php echo esc_html__( 'by', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph -->
+	<!-- wp:group {"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"0.3em"}},"layout":{"type":"flex","justifyContent":"left"}} -->
+	<div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y","isLink":true} /-->
 
-<!-- wp:post-author-name {"isLink":true} /-->
+	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
+	<p class="has-contrast-2-color has-text-color has-link-color">—</p>
+	<!-- /wp:paragraph -->
 
-<!-- wp:post-terms {"term":"category","prefix":"in "} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></div>
+	<!-- wp:paragraph {"fontSize":"small"} -->
+	<p class="has-small-font-size"><?php echo esc_html__( 'by', 'twentytwentyfour' ); ?></p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:post-author-name {"isLink":true} /-->
+
+	<!-- wp:post-terms {"term":"category","prefix":"in "} /--></div>
+	<!-- /wp:group --></div>
+	<!-- /wp:group --></div>
+	<!-- /wp:group -->
+
+	<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
+	<div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+	<!-- /wp:post-template --></div>
+	<!-- /wp:query -->
+</div>
 <!-- /wp:group -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
-<div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-<!-- /wp:post-template --></div>
-<!-- /wp:query -->
+
 
 <!-- wp:separator {"backgroundColor":"base-3","className":"is-style-wide"} -->
 <hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-base-3-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontSize":"1.4rem"}}} -->
-<h2 class="wp-block-heading" style="font-size:1.4rem"><?php echo esc_html__( 'Useful links', 'twentytwentyfour' ); ?></h2>
+<div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
+<h2 class="wp-block-heading" style="font-size:1.6rem"><?php echo esc_html__( 'Links', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size"><?php echo esc_html__( 'Things that I find useful and wanted to share with you.', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph -->
 
 <!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400","textDecoration":"underline"}},"fontSize":"small"} -->
 <!-- wp:navigation-link {"label":"<?php echo esc_html__( 'Latest inflation report', 'twentytwentyfour' ); ?>","url":"#"} /-->
@@ -81,5 +86,7 @@
 
 <!-- wp:spacer {"height":"var:preset|spacing|10"} -->
 <div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer --></div>
+<!-- /wp:spacer -->
+
+</div>
 <!-- /wp:group -->

--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -30,7 +30,7 @@
 <h2 class="wp-block-heading" style="font-size:1.4rem"><?php echo esc_html__( 'Latest Posts', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:query {"queryId":5,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
 <!-- wp:group {"style":{"spacing":{"blockGap":"2px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:post-title {"isLink":true,"fontSize":"medium"} /-->


### PR DESCRIPTION
###  Description

Tidies up the sidebar so that the spacing/font sizes are a bit more consistent. And makes the sidebar look nice in the focused template part view. Closes #340.

### Screenshots

#### Before: 

<img width="1629" alt="CleanShot 2023-09-18 at 14 05 32" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/3c99322f-184a-477d-b013-3d7901bbc03a">

#### After: 

<img width="1556" alt="CleanShot 2023-09-18 at 14 08 38" src="https://github.com/WordPress/twentytwentyfour/assets/1813435/cbf08e25-b160-4315-b9ba-975ee67ba9c1">
