### PR TITLE
Adding a 'name' attribute to the Cardo font family definitions. 

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -251,6 +251,7 @@
 						}
 					],
 					"fontFamily": "Cardo",
+					"name": "Cardo",
 					"slug": "heading"
 				}
 			],


### PR DESCRIPTION

**Description**

With the latest Gutenberg release a 'name' attribute is required in font family definitions.  I believe it has always been required, but the resources would still render.  Now, if it is missing the `<style id='wp-fonts-local'...` resource does not render.

**Testing Instructions**

Ensure Gutenberg plugin is latest (/trunk) and active.
Render any view with the default 'Cardo' font applied.
Note that the font face resources are used.

<img width="918" alt="image" src="https://github.com/WordPress/twentytwentyfour/assets/146530/244a364c-0ab3-4573-9283-8a6949d1220c">

