### PR TITLE
Performance improvement: Ensure styles for the button block only get loaded when the button block is rendered

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -65,3 +65,4 @@
 | @labunchemjong | @labunchemjong |
 | @thetwopct | @bonkerz |
 | @karmacharya50 | @karmacharya50 |
+| aristath | @aristath |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -65,4 +65,4 @@
 | @labunchemjong | @labunchemjong |
 | @thetwopct | @bonkerz |
 | @karmacharya50 | @karmacharya50 |
-| aristath | @aristath |
+| @aristath | @aristath |

--- a/assets/css/button-outline.css
+++ b/assets/css/button-outline.css
@@ -1,0 +1,6 @@
+.wp-block-button.is-style-outline
+	> .wp-block-button__link:not(.has-background):hover {
+	background-color: var(--wp--preset--color--contrast-2);
+	color: var(--wp--preset--color--base);
+	border-color: var(--wp--preset--color--contrast-2);
+}

--- a/functions.php
+++ b/functions.php
@@ -66,6 +66,14 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 	 *
 	 */
 	function twentytwentyfour_block_styles() {
+		/**
+		 * The wp_enqueue_block_style() function allows us to enqueue a stylesheet
+		 * for a specific block. These will only get loaded when the block is rendered
+		 * (both in the editor and on the front end), improving performance
+		 * and reducing the amount of data requested by visitors.
+		 *
+		 * See https://make.wordpress.org/core/2021/12/15/using-multiple-stylesheets-per-block/ for more info.
+		 */
 		wp_enqueue_block_style(
 			'core/button',
 			array(
@@ -73,6 +81,15 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				'src'    => get_template_directory_uri() . '/assets/css/button-outline.css',
 			)
 		);
+
+		/**
+		 * Add the `path` data to our stylesheet.
+		 *
+		 * This will let WordPress determine the best loading strategy for the stylesheet:
+		 * Small stylesheets will get inlined, while larger stylesheets will be loaded separately.
+		 *
+		 * See https://make.wordpress.org/core/2021/07/01/block-styles-loading-enhancements-in-wordpress-5-8/#inlining-small-assets for more info.
+		 */
 		wp_style_add_data( 'twentytwentyfour-button-style-outline', 'path', get_theme_file_path( 'assets/css/button-outline.css' ) );
 
 		register_block_style(

--- a/functions.php
+++ b/functions.php
@@ -66,6 +66,15 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 	 *
 	 */
 	function twentytwentyfour_block_styles() {
+		wp_enqueue_block_style(
+			'core/button',
+			array(
+				'handle' => 'twentytwentyfour-button-style-outline',
+				'src'    => get_template_directory_uri() . '/assets/css/button-outline.css',
+			)
+		);
+		wp_style_add_data( 'twentytwentyfour-button-style-outline', 'path', get_theme_file_path( 'assets/css/button-outline.css' ) );
+
 		register_block_style(
 			'core/details',
 			array(

--- a/style.css
+++ b/style.css
@@ -15,18 +15,6 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 */
 
 /*
- * Control the hover stylings of Button block's Outline style.
- * Unnecessary once block styles are configurable via theme.json
- * https://github.com/WordPress/gutenberg/issues/42794
- */
-
-.wp-block-button.is-style-outline > .wp-block-button__link:not(.has-background):hover {
-	background-color: var(--wp--preset--color--contrast-2);
-	color: var(--wp--preset--color--base);
-	border-color: var(--wp--preset--color--contrast-2);
-}
-
-/*
  * Link styles
  * https://github.com/WordPress/gutenberg/issues/42319
  */


### PR DESCRIPTION
**Description**

This is a performance improvement to ensure that styles for the button block only get enqueued when the block actually exists on the page.

**Testing Instructions**

Add a button block, set the style variation to outline, and check that the styles get applied properly,.
