### PR TITLE
Fix for footer on index template

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,5 +11,6 @@
 	<!-- /wp:heading -->
 	<!-- wp:pattern {"slug":"twentytwentyfour/archive"} /-->
 </main>
+<!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer"} /-->


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Closes https://github.com/WordPress/twentytwentyfour/issues/428

Missing closing tag from this pattern was causing the issue with the footer
