### PR TITLE
Asterisk spacer

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -128,6 +128,13 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				'inline_css' => 'ul.is-style-checkmark-list{list-style-type:"\2713";}ul.is-style-checkmark-list li{padding-inline-start:1ch;}',
 			)
 		);
+		register_block_style(
+			'core/spacer',
+			array(
+				'name'  => 'asterisk',
+				'label' => __( 'Asterisk', 'twentytwentyfour' ),
+			)
+		);
 	}
 endif;
 

--- a/style.css
+++ b/style.css
@@ -23,3 +23,32 @@ a {
 	text-decoration-thickness: 0.0625em;
 	text-underline-offset: 0.15em;
 }
+
+.is-style-asterisk {
+	border: none;
+	width: 22px;
+	height: 21px;
+	min-height: 30px;
+	background-color: currentColor;
+	clip-path: path('M11.93.684v8.039l5.633-5.633 1.216 1.23-5.66 5.66h8.04v1.737H13.2l5.701 5.701-1.23 1.23-5.742-5.742V21h-1.737v-8.094l-5.77 5.77-1.23-1.217 5.743-5.742H.842V9.98h8.162l-5.701-5.7 1.23-1.231 5.66 5.66V.684h1.737Z');
+}
+
+.has-medium-font-size .is-style-asterisk {
+	width: 30px;
+	height: 29px;
+}
+
+.has-large-font-size .is-style-asterisk {
+	width: 35px;
+	height: 34px;
+}
+
+.has-x-large-font-size .is-style-asteriske {
+	width: 45px;
+	height: 44px;
+}
+
+.has-xx-large-font-size .is-style-asterisk {
+	width: 65px;
+	height: 64px;
+}


### PR DESCRIPTION
**Description**
Wrapping the spacer in a group block allows the asterisk to be colored via text group, aligned via the justification options, and has no semantic meaning so it is not announced by screen readers.

**Screenshots**
https://github.com/WordPress/twentytwentyfour/assets/967608/2c215560-036b-4757-8834-416776dc1dfd

**Testing Instructions**

1. Add a group block
2. Add a spacer to the group block
3. Select Asterisk Style on the spacer style
4. Change the color with the group block Text Color
5. Change the alignment with the group block Justification
6. Change the size of the asterisk with the group block Text sizes
