### PR TITLE
Audit template types for insertion options

### DIFF
--- a/patterns/template-archive-writer.php
+++ b/patterns/template-archive-writer.php
@@ -2,7 +2,7 @@
 /**
  * Title: Writer Archive Template
  * Slug: twentytwentyfour/archive-writer
- * Template Types: archive, page
+ * Template Types: archive, category, tag, author, date
  * Viewport width: 1400
  * Inserter: no
  */

--- a/patterns/template-home-portfolio.php
+++ b/patterns/template-home-portfolio.php
@@ -2,7 +2,7 @@
 /**
  * Title: Portfolio Template
  * Slug: twentytwentyfour/template-home-portfolio
- * Template Types: front-page, index, home
+ * Template Types: front-page, index, home, page
  * Viewport width: 1400
  * Inserter: no
  */

--- a/patterns/template-index-writer.php
+++ b/patterns/template-index-writer.php
@@ -2,7 +2,7 @@
 /**
  * Title: Writer Index Template
  * Slug: twentytwentyfour/index-writer
- * Template Types: index, home, page
+ * Template Types: index, home
  * Viewport width: 1400
  * Inserter: no
  */

--- a/patterns/template-search-writer.php
+++ b/patterns/template-search-writer.php
@@ -2,7 +2,7 @@
 /**
  * Title: Writer Search Results Template
  * Slug: twentytwentyfour/search-writer
- * Template Types: search, page
+ * Template Types: search
  * Viewport width: 1400
  * Inserter: no
  */


### PR DESCRIPTION
Fixes #453 - auditing and fixing the page/post types for which patterns will be suggested as starting points.

I've made a first pass at this. Main remaining question I have is whether we should remove `index` from home-writer and home-portfolio. Seems like we wouldn't want those patterns for an index template- but open to feedback.