### PR TITLE
Add portfolio template patterns

### DIFF
--- a/patterns/portfolio-posts.php
+++ b/patterns/portfolio-posts.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Title: List of posts with featured images in three columns
+ * Description: This pattern only shows featured images. Make sure that you have assigned images to your posts.
+ * Slug: twentytwentyfour/portfolio-posts
+ * Categories: query
+ * Block Types: core/query
+ */
+?>
+
+<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":"0","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"wide","layout":{"type":"default"}} -->
+<div class="wp-block-query alignwide">
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"0","right":"0"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
+	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:0">
+
+		<!-- wp:post-template {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"grid","columnCount":3}} -->
+			<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/4","style":{"spacing":{"margin":{"bottom":"0"},"padding":{"bottom":"var:preset|spacing|20"}}}} /-->
+		<!-- /wp:post-template -->
+
+		<!-- wp:spacer {"height":"var:preset|spacing|40","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+		<div style="margin-top:0;margin-bottom:0;height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
+
+		<!-- wp:query-pagination {"paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"space-between"}} -->
+		<!-- wp:query-pagination-previous /-->
+		<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+			<!-- wp:pattern {"slug":"twentytwentyfour/hidden-no-results-content"} /-->
+		<!-- /wp:query-no-results -->
+
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:query -->

--- a/patterns/posts-three-columns.php
+++ b/patterns/posts-three-columns.php
@@ -2,7 +2,7 @@
 /**
  * Title: List of posts with featured images in three columns
  * Description: This pattern only shows featured images. Make sure that you have assigned images to your posts.
- * Slug: twentytwentyfour/portfolio-posts
+ * Slug: twentytwentyfour/posts-three-columns
  * Categories: query
  * Block Types: core/query
  */

--- a/patterns/template-archive-portfolio.php
+++ b/patterns/template-archive-portfolio.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Title: Portfolio Archive Template
+ * Slug: twentytwentyfour/template-archive-portfolio
+ * Template Types: archive
+ * Viewport width: 1400
+ * Inserter: no
+ */
+?>
+
+<!-- wp:group {"style":{"position":{"type":"sticky","top":"0px"}},"layout":{"type":"default"}} -->
+<div class="wp-block-group">
+	<!-- wp:template-part {"slug":"header","theme":"twentytwentyfour"} /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
+<main class="wp-block-group alignfull">
+
+	<!-- wp:query-title {"type":"archive","align":"wide","style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"var:preset|spacing|50"}}}} /-->
+
+	<!-- wp:pattern {"slug":"twentytwentyfour/portfolio-posts"} /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer","theme":"twentytwentyfour"} /-->

--- a/patterns/template-archive-portfolio.php
+++ b/patterns/template-archive-portfolio.php
@@ -19,7 +19,7 @@
 
 	<!-- wp:query-title {"type":"archive","align":"wide","style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"var:preset|spacing|50"}}}} /-->
 
-	<!-- wp:pattern {"slug":"twentytwentyfour/portfolio-posts"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfour/posts-three-columns"} /-->
 
 </main>
 <!-- /wp:group -->

--- a/patterns/template-index-portfolio.php
+++ b/patterns/template-index-portfolio.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Title: Portfolio Index Template
+ * Slug: twentytwentyfour/template-index-portfolio
+ * Template Types: index
+ * Viewport width: 1400
+ */
+?>
+
+<!-- wp:group {"style":{"position":{"type":"sticky","top":"0px"}},"layout":{"type":"default"}} -->
+<div class="wp-block-group">
+	<!-- wp:template-part {"slug":"header","theme":"twentytwentyfour"} /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
+<main class="wp-block-group alignfull">
+	<!-- wp:heading {"level":1,"className="screen-reader-text} -->
+	<h1 class="wp-block-heading screen-reader-text"><?php echo esc_html__( 'Posts', 'twentytwentyfour' ); ?></h1>
+	<!-- /wp:heading -->
+
+	<!-- wp:pattern {"slug":"twentytwentyfour/offset-grid-image-posts"} /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer","theme":"twentytwentyfour"} /-->

--- a/patterns/template-search-portfolio.php
+++ b/patterns/template-search-portfolio.php
@@ -23,7 +23,7 @@
 	<div class="wp-block-columns alignwide">
 		<!-- wp:column {"width":"66.66%"} -->
 		<div class="wp-block-column" style="flex-basis:66.66%">
-			<!-- wp:search {"label":"Search","showLabel":false,"width":null,"widthUnit":"%","buttonText":"Search","fontSize":"medium"} /-->
+			<!-- wp:pattern {"slug":"twentytwentyfour/hidden-search"} /-->
 		</div>
 		<!-- /wp:column -->
 	

--- a/patterns/template-search-portfolio.php
+++ b/patterns/template-search-portfolio.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Title: Portfolio Search Template
+ * Slug: twentytwentyfour/template-search-portfolio
+ * Template Types: search
+ * Viewport width: 1400
+ * Inserter: no
+ */
+?>
+
+<!-- wp:group {"style":{"position":{"type":"sticky","top":"0px"}},"layout":{"type":"default"}} -->
+<div class="wp-block-group">
+	<!-- wp:template-part {"slug":"header","theme":"twentytwentyfour"} /-->
+</div>
+<!-- /wp:group -->
+
+
+<!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
+<main class="wp-block-group alignfull">
+	<!-- wp:query-title {"type":"search","align":"wide","style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|10"}}}} /-->
+
+	<!-- wp:columns {"align":"wide"} -->
+	<div class="wp-block-columns alignwide">
+		<!-- wp:column {"width":"66.66%"} -->
+		<div class="wp-block-column" style="flex-basis:66.66%">
+			<!-- wp:search {"label":"Search","showLabel":false,"width":null,"widthUnit":"%","buttonText":"Search","fontSize":"medium"} /-->
+		</div>
+		<!-- /wp:column -->
+	
+		<!-- wp:column {"width":"33.33%"} -->
+		<div class="wp-block-column" style="flex-basis:33.33%">
+			<!-- wp:spacer {"height":"0"} -->
+			<div style="height:0" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+	
+	<!-- wp:pattern {"slug":"twentytwentyfour/portfolio-posts"} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer","theme":"twentytwentyfour"} /-->

--- a/patterns/template-search-portfolio.php
+++ b/patterns/template-search-portfolio.php
@@ -37,7 +37,7 @@
 	</div>
 	<!-- /wp:columns -->
 	
-	<!-- wp:pattern {"slug":"twentytwentyfour/portfolio-posts"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfour/posts-three-columns"} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
**Description**
This PR adds:

1. A query loop pattern where the post template only has the featured image block
2. An index template pattern
3. A search template pattern
4. An archive template pattern

**The PR does not attempt to solve the blank spaces for posts that do not have featured images.**

Closes: https://github.com/WordPress/twentytwentyfour/issues/426, 
https://github.com/WordPress/twentytwentyfour/issues/425,
https://github.com/WordPress/twentytwentyfour/issues/351

Repalces https://github.com/WordPress/twentytwentyfour/pull/368

**Testing Instructions**
Search: Open the search template, delete all posts, save and refresh the editor. Select the pattern that only has featured images.
Archive: Open the archive template  delete all posts, save and refresh the editor. Select the pattern that only has featured images.

Index: I was not able to trigger the pattern selection modal only by deleting all the posts.
Instead I had to remove "inserter:no" and insert the portfolio index pattern from the inserter.