### PR TITLE
Move the link style CSS to theme.json

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -8,32 +8,6 @@
  * @since Twenty Twenty Four 1.0
  */
 
-if ( ! function_exists( 'twentytwentyfour_styles' ) ) :
-
-	/**
-	 * Enqueue styles.
-	 *
-	 * @return void
-	 * @since Twenty Twenty Four 1.0
-	 *
-	 */
-	function twentytwentyfour_styles() {
-		// Register theme stylesheet.
-		wp_register_style(
-			'twentytwentyfour-style',
-			get_template_directory_uri() . '/style.css',
-			array(),
-			wp_get_theme()->get( 'Version' )
-		);
-
-		// Enqueue theme stylesheet.
-		wp_enqueue_style( 'twentytwentyfour-style' );
-	}
-
-endif;
-
-add_action( 'wp_enqueue_scripts', 'twentytwentyfour_styles' );
-
 /**
  * Register block Styles
  */

--- a/functions.php
+++ b/functions.php
@@ -8,25 +8,6 @@
  * @since Twenty Twenty Four 1.0
  */
 
-
-if ( ! function_exists( 'twentytwentyfour_support' ) ) :
-
-	/**
-	 * Sets up theme defaults and registers support for various WordPress features.
-	 *
-	 * @return void
-	 * @since Twenty Twenty Four 1.0
-	 *
-	 */
-	function twentytwentyfour_support() {
-		// Enqueue editor styles.
-		add_editor_style( 'style.css' );
-	}
-
-endif;
-
-add_action( 'after_setup_theme', 'twentytwentyfour_support' );
-
 if ( ! function_exists( 'twentytwentyfour_styles' ) ) :
 
 	/**

--- a/style.css
+++ b/style.css
@@ -13,13 +13,3 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyfour
 Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready, wide-blocks, block-styles, style-variations, accessibility-ready, blog, portfolio, news
 */
-
-/*
- * Link styles
- * https://github.com/WordPress/gutenberg/issues/42319
- */
-
-a {
-	text-decoration-thickness: 0.0625em;
-	text-underline-offset: 0.15em;
-}

--- a/theme.json
+++ b/theme.json
@@ -779,6 +779,7 @@
 			"background": "var(--wp--preset--color--base)",
 			"text": "var(--wp--preset--color--contrast)"
 		},
+		"css": "a{text-decoration-thickness:0.0625em;text-underline-offset: 0.15em}",
 		"elements": {
 			"button": {
 				":active": {


### PR DESCRIPTION
**Description**
By moving the last remaining CSS to theme.json, the style.css file no longer needs to be enqueued.

