### PR TITLE
Fix Portfolio Post Template: Misplaced post meta

### DIFF
--- a/patterns/template-single-portfolio.php
+++ b/patterns/template-single-portfolio.php
@@ -23,11 +23,11 @@
 
 	<!-- wp:columns {"align":"wide"} -->
 	<div class="wp-block-columns alignwide"><!-- wp:column {"width":"45%"} -->
-	<div class="wp-block-column" style="flex-basis:45%"></div>
+	<div class="wp-block-column" style="flex-basis:45%"><!-- wp:template-part {"slug":"post-meta","theme":"twentytwentyfour"} /--></div>
 	<!-- /wp:column -->
 
 	<!-- wp:column {"width":"55%"} -->
-	<div class="wp-block-column" style="flex-basis:55%"><!-- wp:template-part {"slug":"post-meta"} /--></div>
+	<div class="wp-block-column" style="flex-basis:55%"></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->
 
@@ -38,4 +38,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer-portfolio","area":"footer","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer-portfolio","area":"footer","tagName":"footer","theme":"twentytwentyfour"} /-->

--- a/patterns/template-single-portfolio.php
+++ b/patterns/template-single-portfolio.php
@@ -21,15 +21,9 @@
 
 	<!-- wp:post-featured-image {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} /-->
 
-	<!-- wp:columns {"align":"wide"} -->
-	<div class="wp-block-columns alignwide"><!-- wp:column {"width":"45%"} -->
-	<div class="wp-block-column" style="flex-basis:45%"><!-- wp:template-part {"slug":"post-meta","theme":"twentytwentyfour"} /--></div>
-	<!-- /wp:column -->
-
-	<!-- wp:column {"width":"55%"} -->
-	<div class="wp-block-column" style="flex-basis:55%"></div>
-	<!-- /wp:column --></div>
-	<!-- /wp:columns -->
+	<!-- wp:group {"align":"wide","layout":{"type":"constrained","justifyContent":"left"}} -->
+	<div class="wp-block-group alignwide"><!-- wp:template-part {"slug":"post-meta","theme":"twentytwentyfour"} /--></div>
+	<!-- /wp:group -->
 
 	<!-- wp:spacer {"height":"var:preset|spacing|40"} -->
 	<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>

--- a/patterns/template-single-portfolio.php
+++ b/patterns/template-single-portfolio.php
@@ -38,4 +38,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer-portfolio","area":"footer","tagName":"footer","theme":"twentytwentyfour"} /-->
+<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer","theme":"twentytwentyfour"} /-->


### PR DESCRIPTION
**Description**
I moved the post meta template part from the right to the left column, and added the theme slug to the template parts.
I replaced the footer with the default footer.

**Screenshots**
![Single portfolio](https://github.com/WordPress/twentytwentyfour/assets/7422055/9e1852b6-27e0-4832-ac78-513ecd7e73a4)

**Testing Instructions**
In the Site Editor, select the single post template. Delete all blocks. Save. Refresh to trigger the pattern selection modal. Add the correct pattern and view the post meta.

