### PR TITLE
Fix checkmarks block style

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -74,8 +74,8 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 		register_block_style(
 			'core/list',
 			array(
-				'name'       => 'checkmark-list',
-				'label'      => __( 'Checkmark', 'twentytwentyfour' ),
+				'name'         => 'checkmark-list',
+				'label'        => __( 'Checkmark', 'twentytwentyfour' ),
 				/*
 				 * Styles for the custom checkmark list block style
 				 * https://github.com/WordPress/gutenberg/issues/51480

--- a/functions.php
+++ b/functions.php
@@ -80,7 +80,7 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				 * Styles for the custom checkmark list block style
 				 * https://github.com/WordPress/gutenberg/issues/51480
 				 */
-				'inline_css' => 'ul.is-style-checkmark-list{list-style-type:"\2713";}ul.is-style-checkmark-list li{padding-inline-start:1ch;}',
+				'inline_style' => 'ul.is-style-checkmark-list{list-style-type:"\2713";}ul.is-style-checkmark-list li{padding-inline-start:1ch;}',
 			)
 		);
 	}


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->
Fixes https://github.com/WordPress/twentytwentyfour/issues/466

For some reason, this block style had the wrong arg name for the inline CSS. This should fix it