### PR TITLE
Asterisk as heading variation

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -86,8 +86,8 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 		register_block_style(
 			'core/heading',
 			array(
-				'name'       => 'asterisk',
-				'label'      => __( 'With asterisk', 'twentytwentyfour' ),
+				'name'         => 'asterisk',
+				'label'        => __( 'With asterisk', 'twentytwentyfour' ),
 				/* TODO: RTL considerations */
 				'inline_style' => ".is-style-asterisk:before{content:'';width: 1.5rem;height:3rem;background: var(--wp--preset--color--contrast-2);
 					clip-path: path('M11.93.684v8.039l5.633-5.633 1.216 1.23-5.66 5.66h8.04v1.737H13.2l5.701 5.701-1.23 1.23-5.742-5.742V21h-1.737v-8.094l-5.77 5.77-1.23-1.217 5.743-5.742H.842V9.98h8.162l-5.701-5.7 1.23-1.231 5.66 5.66V.684h1.737Z'); display: block;}.is-style-asterisk.has-text-align-center:before{margin: 0 auto;}.is-style-asterisk.has-text-align-right:before{margin-left: auto;}.rtl .is-style-asterisk.has-text-align-left:before{margin-right: auto;}",

--- a/functions.php
+++ b/functions.php
@@ -83,6 +83,16 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				'inline_css' => 'ul.is-style-checkmark-list{list-style-type:"\2713";}ul.is-style-checkmark-list li{padding-inline-start:1ch;}',
 			)
 		);
+		register_block_style(
+			'core/heading',
+			array(
+				'name'       => 'asterisk',
+				'label'      => __( 'With asterisk', 'twentytwentyfour' ),
+				/* TODO: RTL considerations */
+				'inline_style' => ".is-style-asterisk:before{content:'';width: 1.5rem;height:3rem;background: var(--wp--preset--color--contrast-2);
+					clip-path: path('M11.93.684v8.039l5.633-5.633 1.216 1.23-5.66 5.66h8.04v1.737H13.2l5.701 5.701-1.23 1.23-5.742-5.742V21h-1.737v-8.094l-5.77 5.77-1.23-1.217 5.743-5.742H.842V9.98h8.162l-5.701-5.7 1.23-1.231 5.66 5.66V.684h1.737Z'); display: block;}.is-style-asterisk.has-text-align-center:before{margin: 0 auto;}.is-style-asterisk.has-text-align-right:before{margin-left: auto;}",
+			)
+		);
 	}
 endif;
 

--- a/functions.php
+++ b/functions.php
@@ -90,7 +90,7 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				'label'      => __( 'With asterisk', 'twentytwentyfour' ),
 				/* TODO: RTL considerations */
 				'inline_style' => ".is-style-asterisk:before{content:'';width: 1.5rem;height:3rem;background: var(--wp--preset--color--contrast-2);
-					clip-path: path('M11.93.684v8.039l5.633-5.633 1.216 1.23-5.66 5.66h8.04v1.737H13.2l5.701 5.701-1.23 1.23-5.742-5.742V21h-1.737v-8.094l-5.77 5.77-1.23-1.217 5.743-5.742H.842V9.98h8.162l-5.701-5.7 1.23-1.231 5.66 5.66V.684h1.737Z'); display: block;}.is-style-asterisk.has-text-align-center:before{margin: 0 auto;}.is-style-asterisk.has-text-align-right:before{margin-left: auto;}",
+					clip-path: path('M11.93.684v8.039l5.633-5.633 1.216 1.23-5.66 5.66h8.04v1.737H13.2l5.701 5.701-1.23 1.23-5.742-5.742V21h-1.737v-8.094l-5.77 5.77-1.23-1.217 5.743-5.742H.842V9.98h8.162l-5.701-5.7 1.23-1.231 5.66 5.66V.684h1.737Z'); display: block;}.is-style-asterisk.has-text-align-center:before{margin: 0 auto;}.is-style-asterisk.has-text-align-right:before{margin-left: auto;}.rtl .is-style-asterisk.has-text-align-left:before{margin-right: auto;}",
 			)
 		);
 	}

--- a/functions.php
+++ b/functions.php
@@ -88,9 +88,7 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 			array(
 				'name'         => 'asterisk',
 				'label'        => __( 'With asterisk', 'twentytwentyfour' ),
-				/* TODO: RTL considerations */
-				'inline_style' => ".is-style-asterisk:before{content:'';width: 1.5rem;height:3rem;background: var(--wp--preset--color--contrast-2);
-					clip-path: path('M11.93.684v8.039l5.633-5.633 1.216 1.23-5.66 5.66h8.04v1.737H13.2l5.701 5.701-1.23 1.23-5.742-5.742V21h-1.737v-8.094l-5.77 5.77-1.23-1.217 5.743-5.742H.842V9.98h8.162l-5.701-5.7 1.23-1.231 5.66 5.66V.684h1.737Z'); display: block;}.is-style-asterisk.has-text-align-center:before{margin: 0 auto;}.is-style-asterisk.has-text-align-right:before{margin-left: auto;}.rtl .is-style-asterisk.has-text-align-left:before{margin-right: auto;}",
+				'inline_style' => ".is-style-asterisk:before{content:'';width: 1.5rem;height:3rem;background: var(--wp--preset--color--contrast-2, currentColor);clip-path: path('M11.93.684v8.039l5.633-5.633 1.216 1.23-5.66 5.66h8.04v1.737H13.2l5.701 5.701-1.23 1.23-5.742-5.742V21h-1.737v-8.094l-5.77 5.77-1.23-1.217 5.743-5.742H.842V9.98h8.162l-5.701-5.7 1.23-1.231 5.66 5.66V.684h1.737Z'); display: block;}.is-style-asterisk.has-text-align-center:before{margin: 0 auto;}.is-style-asterisk.has-text-align-right:before{margin-left: auto;}.rtl .is-style-asterisk.has-text-align-left:before{margin-right: auto;}",
 			)
 		);
 	}

--- a/patterns/feature-grid.php
+++ b/patterns/feature-grid.php
@@ -9,12 +9,9 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"backgroundColor":"base-2","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-base-2-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"center","textColor":"contrast-2","fontSize":"large"} -->
-<p class="has-text-align-center has-contrast-2-color has-text-color has-large-font-size">✳︎</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:heading {"textAlign":"center"} -->
-<h2 class="wp-block-heading has-text-align-center"><?php echo esc_html_x( 'A passion for creating spaces', 'Heading of the features', 'twentytwentyfour' ); ?></h2>
+<div class="wp-block-group">
+<!-- wp:heading {"textAlign":"center","className":"is-style-asterisk"} -->
+<h2 class="wp-block-heading has-text-align-center is-style-asterisk"><?php echo esc_html_x( 'A passion for creating spaces', 'Heading of the features', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
@@ -32,13 +29,10 @@
 
 <!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|40"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
-<div class="wp-block-column"><!-- wp:paragraph {"align":"left","textColor":"contrast-2","fontSize":"large"} -->
-<p class="has-text-align-left has-contrast-2-color has-text-color has-large-font-size">✳︎</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph {"align":"left","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium"} -->
-<p class="has-text-align-left has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Renovation and restoration', 'Sample feature heading', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph -->
+<div class="wp-block-column">
+<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
+<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Renovation and restoration', 'Sample feature heading', 'twentytwentyfour' ); ?></h3>
+<!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"left"} -->
 <p class="has-text-align-left"><?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?></p>
@@ -46,13 +40,10 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
-<div class="wp-block-column"><!-- wp:paragraph {"align":"left","textColor":"contrast-2","fontSize":"large"} -->
-<p class="has-text-align-left has-contrast-2-color has-text-color has-large-font-size">✳︎</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph {"align":"left","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium"} -->
-<p class="has-text-align-left has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Continuous Support', 'Sample feature heading', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph -->
+<div class="wp-block-column">
+<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
+<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Continuous Support', 'Sample feature heading', 'twentytwentyfour' ); ?></h3>
+<!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"left"} -->
 <p class="has-text-align-left"><?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?></p>
@@ -60,13 +51,10 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
-<div class="wp-block-column"><!-- wp:paragraph {"align":"left","textColor":"contrast-2","fontSize":"large"} -->
-<p class="has-text-align-left has-contrast-2-color has-text-color has-large-font-size">✳︎</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph {"align":"left","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium"} -->
-<p class="has-text-align-left has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'App Access', 'Sample feature heading', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph -->
+<div class="wp-block-column">
+<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
+<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'App Access', 'Sample feature heading', 'twentytwentyfour' ); ?></h3>
+<!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"left"} -->
 <p class="has-text-align-left"><?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?></p>
@@ -80,13 +68,10 @@
 
 <!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|40"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
-<div class="wp-block-column"><!-- wp:paragraph {"align":"left","textColor":"contrast-2","fontSize":"large"} -->
-<p class="has-text-align-left has-contrast-2-color has-text-color has-large-font-size">✳︎</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph {"align":"left","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium"} -->
-<p class="has-text-align-left has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Consulting', 'Sample feature heading', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph -->
+<div class="wp-block-column">
+<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
+<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Consulting', 'Sample feature heading', 'twentytwentyfour' ); ?></h3>
+<!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"left"} -->
 <p class="has-text-align-left"><?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?></p>
@@ -94,13 +79,10 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
-<div class="wp-block-column"><!-- wp:paragraph {"align":"left","textColor":"contrast-2","fontSize":"large"} -->
-<p class="has-text-align-left has-contrast-2-color has-text-color has-large-font-size">✳︎</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph {"align":"left","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium"} -->
-<p class="has-text-align-left has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Project Management', 'Sample feature heading', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph -->
+<div class="wp-block-column">
+<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
+<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Project Management', 'Sample feature heading', 'twentytwentyfour' ); ?></h3>
+<!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"left"} -->
 <p class="has-text-align-left"><?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?></p>
@@ -108,13 +90,10 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
-<div class="wp-block-column"><!-- wp:paragraph {"align":"left","textColor":"contrast-2","fontSize":"large"} -->
-<p class="has-text-align-left has-contrast-2-color has-text-color has-large-font-size">✳︎</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph {"align":"left","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"medium"} -->
-<p class="has-text-align-left has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Architectural Solutions', 'Sample feature heading', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph -->
+<div class="wp-block-column">
+<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
+<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Architectural Solutions', 'Sample feature heading', 'twentytwentyfour' ); ?></h3>
+<!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"left"} -->
 <p class="has-text-align-left"><?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?></p>

--- a/patterns/features-with-images.php
+++ b/patterns/features-with-images.php
@@ -14,8 +14,8 @@
 <p class="has-text-align-center has-contrast-2-color has-text-color has-link-color has-large-font-size">✳︎</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading {"textAlign":"center"} -->
-<h2 class="wp-block-heading has-text-align-center"><?php echo esc_html_x( 'An array of resources', 'Sample content for heading of the section.', 'twentytwentyfour' ); ?></h2>
+<!-- wp:heading {"textAlign":"center","className":"is-style-asterisk"} -->
+<h2 class="wp-block-heading has-text-align-center is-style-asterisk"><?php echo esc_html_x( 'An array of resources', 'Sample content for heading of the section.', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
@@ -33,9 +33,8 @@
 <div class="wp-block-group"><!-- wp:paragraph {"align":"left","style":{"layout":{"selfStretch":"fit","flexSize":null},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"contrast-2","fontSize":"large"} -->
 <p class="has-text-align-left has-contrast-2-color has-text-color has-link-color has-large-font-size">✳︎</p>
 <!-- /wp:paragraph -->
-
-<!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading"><?php echo esc_html_x( 'Études Architect App', 'A heading for the list.', 'twentytwentyfour' ); ?></h3>
+<!-- wp:heading {"level":3,"className":"is-style-asterisk"} -->
+<h3 class="wp-block-heading is-style-asterisk"><?php echo esc_html_x( 'Études Architect App', 'A heading for the list.', 'twentytwentyfour' ); ?></h3>
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 
@@ -82,8 +81,8 @@
 <p class="has-text-align-left has-contrast-2-color has-text-color has-link-color has-large-font-size">✳︎</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading"><?php echo esc_html_x( 'Études Newsletter', 'A heading for the list.', 'twentytwentyfour' ); ?></h3>
+<!-- wp:heading {"level":3,"className":"is-style-asterisk"} -->
+<h3 class="wp-block-heading is-style-asterisk"><?php echo esc_html_x( 'Études Newsletter', 'A heading for the list.', 'twentytwentyfour' ); ?></h3>
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 

--- a/patterns/features-with-images.php
+++ b/patterns/features-with-images.php
@@ -10,9 +10,7 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"contrast-2","fontSize":"large"} -->
-<p class="has-text-align-center has-contrast-2-color has-text-color has-link-color has-large-font-size">✳︎</p>
-<!-- /wp:paragraph -->
+<div class="wp-block-group">
 
 <!-- wp:heading {"textAlign":"center","className":"is-style-asterisk"} -->
 <h2 class="wp-block-heading has-text-align-center is-style-asterisk"><?php echo esc_html_x( 'An array of resources', 'Sample content for heading of the section.', 'twentytwentyfour' ); ?></h2>
@@ -30,9 +28,7 @@
 <!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|60"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center","width":"40%"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:40%"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"left","style":{"layout":{"selfStretch":"fit","flexSize":null},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"contrast-2","fontSize":"large"} -->
-<p class="has-text-align-left has-contrast-2-color has-text-color has-link-color has-large-font-size">✳︎</p>
-<!-- /wp:paragraph -->
+<div class="wp-block-group">
 <!-- wp:heading {"level":3,"className":"is-style-asterisk"} -->
 <h3 class="wp-block-heading is-style-asterisk"><?php echo esc_html_x( 'Études Architect App', 'A heading for the list.', 'twentytwentyfour' ); ?></h3>
 <!-- /wp:heading --></div>
@@ -77,9 +73,7 @@
 
 <!-- wp:column {"verticalAlignment":"center","width":"40%"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:40%"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"left","style":{"layout":{"selfStretch":"fit","flexSize":null},"elements":{"link":{"color":{"text":"var:preset|color|custom-borders"}}}},"textColor":"contrast-2","fontSize":"large"} -->
-<p class="has-text-align-left has-contrast-2-color has-text-color has-link-color has-large-font-size">✳︎</p>
-<!-- /wp:paragraph -->
+<div class="wp-block-group">
 
 <!-- wp:heading {"level":3,"className":"is-style-asterisk"} -->
 <h3 class="wp-block-heading is-style-asterisk"><?php echo esc_html_x( 'Études Newsletter', 'A heading for the list.', 'twentytwentyfour' ); ?></h3>


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Another idea for https://github.com/WordPress/twentytwentyfour/pull/51

Closes #51

Following @carolinan input that this makes more sense semantically to belong to the heading if we are going to follow the block style route, which I agree. The user won't have control over the color, it will always use Contrast 2, which is NOT the same color as the heading, as per the design. There's no way around this. Also we need to have RTL in mind, I have added CSS for centered and right alignment, but we need to see what happens for RTL.

So far this is my preferred option of all the ones we've explored, since it covers most of the requirements and feels a little less hacky or confusing for users. And it doesn't add any markup for screen readers.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

<img width="1381" alt="Screenshot 2023-09-21 at 12 57 19" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/ab8abd2d-0e87-4e09-a5e0-004c12f2ece2">

