### PR TITLE
Add a hidden search pattern

### DIFF
--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -13,4 +13,4 @@
 <!-- wp:paragraph -->
 <p><?php echo esc_html_x( 'The page you are looking for doesn’t exist, or it has been moved. Please try searching using the form below.', 'Message to convey that a webpage could not be found', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:search {"label":"<?php echo esc_attr_x( 'Search', 'search form label', 'twentytwentyfour' ); ?>","showLabel":false,"buttonText":"<?php echo esc_attr_x( 'Search', 'search button text', 'twentytwentyfour' ); ?>"} /-->
+<!-- wp:pattern {"slug":"twentytwentyfour/hidden-search"} /-->

--- a/patterns/hidden-search.php
+++ b/patterns/hidden-search.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Title: Hidden Search form
+ * Slug: twentytwentyfour/hidden-search
+ * Inserter: no
+ */
+
+?>
+
+<!-- wp:search {"label":"<?php echo esc_attr_x( 'Search', 'search form label', 'twentytwentyfour' ); ?>","showLabel":false,"buttonText":"<?php echo esc_attr_x( 'Search', 'search button text', 'twentytwentyfour' ); ?>","fontSize":"medium"} /-->

--- a/patterns/template-search-writer.php
+++ b/patterns/template-search-writer.php
@@ -19,7 +19,7 @@
 	<!-- wp:group {"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
 		<!-- wp:query-title {"type":"search","style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|30"}}}} /-->
-		<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","fontSize":"medium"} /-->
+		<!-- wp:pattern {"slug":"twentytwentyfour/hidden-search"} /-->
 	</div>
 	<!-- /wp:group -->
 	<!-- wp:pattern {"slug":"twentytwentyfour/posts-one-column"} /-->

--- a/templates/search.html
+++ b/templates/search.html
@@ -13,7 +13,7 @@
 	<div class="wp-block-columns alignwide">
 		<!-- wp:column {"width":"66.66%"} -->
 		<div class="wp-block-column" style="flex-basis:66.66%">
-			<!-- wp:search {"label":"Search","showLabel":false,"width":null,"widthUnit":"%","buttonText":"Search","fontSize":"medium"} /-->
+			<!-- wp:pattern {"slug":"twentytwentyfour/hidden-search"} /-->
 		</div>
 		<!-- /wp:column -->
 	


### PR DESCRIPTION
**Description**
Replaces the search block with a pattern with translatable label and button text.

**Testing Instructions**
View each of the updated patterns and confirm that the search block still works correctly:
404,
search,
search-writer
