### PR TITLE
Update `posts-featured.php`, show sticky post only in one column

### DIFF
--- a/patterns/posts-featured.php
+++ b/patterns/posts-featured.php
@@ -19,7 +19,7 @@
 
 <!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|30"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"60%"} -->
-<div class="wp-block-column" style="flex-basis:60%"><!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+<div class="wp-block-column" style="flex-basis:60%"><!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false}} -->
 <div class="wp-block-query"><!-- wp:post-template {"style":{"spacing":{"blockGap":"0"}}} -->
 <!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/4"} /-->
 


### PR DESCRIPTION
**Description**

If there are sticky posts, they would show up in both of the query loops of this pattern. By setting `"sticky":"exclude"` to the query loop on the left, a sticky post only shows up on the right column.

This does not show in the backend but works on the frontend.

**Screenshots**

![CleanShot 2023-09-21 at 17 15 12@2x](https://github.com/WordPress/twentytwentyfour/assets/7585600/83e05436-8fdb-46d0-8ada-fdc0768c4625)

**Testing Instructions**

1. Create a sticky post if there's none
2. Open up home page or page where this pattern is inserted
