### PR TITLE
Moved Schema in top in milky style variation

### DIFF
--- a/styles/milky.json
+++ b/styles/milky.json
@@ -1,7 +1,7 @@
 {
-	"title": "Milky",
-	"version": 2,
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Milky",	
 	"settings": {
 		"color": {
 			"palette": [


### PR DESCRIPTION
Moved Schema in top

As per WordPress developer guide [Reference](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/#developing-with-theme-json)
