### PR TITLE
Remove right margin from Pill style links

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -68,7 +68,7 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				 * Styles variation for post terms
 				 * https://github.com/WordPress/gutenberg/issues/24956
 				 */
-				'inline_style' => '.is-style-pill a,.is-style-pill span:not([class], [data-rich-text-placeholder]){display:inline-block;background-color: #f2f2f2;padding:6px 14px;border-radius:16px;margin:0 10px 10px 0;}.is-style-pill a:hover{background-color:#eee;}',
+				'inline_style' => '.is-style-pill a,.is-style-pill span:not([class], [data-rich-text-placeholder]){display:inline-block;background-color:#f2f2f2;padding:6px 14px;border-radius:16px;margin:0 0 10px;}.is-style-pill a:hover{background-color:#eee;}',
 			)
 		);
 		register_block_style(

--- a/functions.php
+++ b/functions.php
@@ -68,7 +68,7 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				 * Styles variation for post terms
 				 * https://github.com/WordPress/gutenberg/issues/24956
 				 */
-				'inline_style' => '.is-style-pill a,.is-style-pill span:not([class], [data-rich-text-placeholder]){display:inline-block;background-color:#f2f2f2;padding:6px 14px;border-radius:16px;margin:0 0 10px;}.is-style-pill a:hover{background-color:#eee;}',
+				'inline_style' => '.is-style-pill a,.is-style-pill span:not([class], [data-rich-text-placeholder]){display:inline-block;background-color:var(--wp--preset--color--base-2);padding:0.375rem 0.875rem;border-radius:var(--wp--preset--spacing--20);}.is-style-pill a:hover{background-color:var(--wp--preset--color--contrast-3);}',
 			)
 		);
 		register_block_style(


### PR DESCRIPTION
**Description**

In #320, the Pill-style taxonomy links were given both bottom and right margins.

The right margin is not mirrored for right-to-left languages (#356), but I do not think the side margin is necessary.

If more space is desired, maybe giving the `.wp-block-post-terms__separator` element a `min-width` could be better.

**Screenshots**

Tags blocks with right margin (LTR)

![Tags with right margin in English](https://github.com/WordPress/twentytwentyfour/assets/17100257/07cd7c0a-7b72-43bd-9c22-bdce472f63b9)

Tags blocks, removing the side margin (LTR)

![Tags without the side margin in English](https://github.com/WordPress/twentytwentyfour/assets/17100257/3aa97111-1713-4ba4-9ae7-7251700c4f7e)

Tags blocks with right margin (RTL)

![Tags with right margin, setting the language to Hebrew](https://github.com/WordPress/twentytwentyfour/assets/17100257/7f8c24fb-bef6-45c3-ba3d-52fd85588d25)

Tags blocks, removing the side margin (RTL)

![Tags without the side margin, using Hebrew as the RTL language](https://github.com/WordPress/twentytwentyfour/assets/17100257/55925da4-8c55-48c2-986f-718d6016f6cf)

**Testing Instructions**

1. Activate the theme.
2. Create a post.
3. Insert a Tags block (or another taxonomy).
4. Add tags to the post.
5. Save the post and view it on the front.
6. Go to the Site Editor and select the Single Posts template. If you do not already have a Tags block in that template, add one.
7. Visit the post again.