### PR TITLE
Renamed query patterns

### DIFF
--- a/patterns/posts-three-columns-images.php
+++ b/patterns/posts-three-columns-images.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Title: List of posts in three columns
- * Description: The default post list with featured images, title, date, author, categories and excerpt.
- * Slug: twentytwentyfour/archive
+ * Title: List of posts with featured images in three columns
+ * Description: This pattern only shows featured images. Make sure that you have assigned images to your posts.
+ * Slug: twentytwentyfour/posts-three-columns-images
  * Categories: query
  * Block Types: core/query
  */
@@ -14,23 +14,7 @@
 	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:0">
 
 		<!-- wp:post-template {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"grid","columnCount":3}} -->
-
 			<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/4","style":{"spacing":{"margin":{"bottom":"0"},"padding":{"bottom":"var:preset|spacing|20"}}}} /-->
-
-			<!-- wp:group {"style":{"spacing":{"blockGap":"10px","margin":{"top":"var:preset|spacing|20"},"padding":{"top":"0"}}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
-			<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20);padding-top:0">
-				<!-- wp:post-title {"isLink":true,"style":{"layout":{"flexSize":"min(2.5rem, 3vw)","selfStretch":"fixed"}},"fontSize":"large"} /-->
-
-				<!-- wp:template-part {"slug":"post-meta"} /-->
-
-				<!-- wp:post-excerpt {"style":{"layout":{"flexSize":"min(2.5rem, 3vw)","selfStretch":"fixed"}},"textColor":"contrast-2","fontSize":"small"} /-->
-
-				<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"min(2.5rem, 3vw)","selfStretch":"fixed"}}} -->
-				<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
-				<!-- /wp:spacer -->
-			</div>
-			<!-- /wp:group -->
-
 		<!-- /wp:post-template -->
 
 		<!-- wp:spacer {"height":"var:preset|spacing|40","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->

--- a/patterns/posts-three-columns.php
+++ b/patterns/posts-three-columns.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: List of posts with featured images in three columns
- * Description: This pattern only shows featured images. Make sure that you have assigned images to your posts.
+ * Title: List of posts in three columns
+ * Description: The default post list with featured images, title, date, author, categories and excerpt.
  * Slug: twentytwentyfour/posts-three-columns
  * Categories: query
  * Block Types: core/query
@@ -14,7 +14,23 @@
 	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:0">
 
 		<!-- wp:post-template {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"grid","columnCount":3}} -->
+
 			<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/4","style":{"spacing":{"margin":{"bottom":"0"},"padding":{"bottom":"var:preset|spacing|20"}}}} /-->
+
+			<!-- wp:group {"style":{"spacing":{"blockGap":"10px","margin":{"top":"var:preset|spacing|20"},"padding":{"top":"0"}}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
+			<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20);padding-top:0">
+				<!-- wp:post-title {"isLink":true,"style":{"layout":{"flexSize":"min(2.5rem, 3vw)","selfStretch":"fixed"}},"fontSize":"large"} /-->
+
+				<!-- wp:template-part {"slug":"post-meta"} /-->
+
+				<!-- wp:post-excerpt {"style":{"layout":{"flexSize":"min(2.5rem, 3vw)","selfStretch":"fixed"}},"textColor":"contrast-2","fontSize":"small"} /-->
+
+				<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"min(2.5rem, 3vw)","selfStretch":"fixed"}}} -->
+				<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
+				<!-- /wp:spacer -->
+			</div>
+			<!-- /wp:group -->
+
 		<!-- /wp:post-template -->
 
 		<!-- wp:spacer {"height":"var:preset|spacing|40","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->

--- a/patterns/template-archive-portfolio.php
+++ b/patterns/template-archive-portfolio.php
@@ -19,7 +19,7 @@
 
 	<!-- wp:query-title {"type":"archive","align":"wide","style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"var:preset|spacing|50"}}}} /-->
 
-	<!-- wp:pattern {"slug":"twentytwentyfour/posts-three-columns"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfour/posts-three-columns-images"} /-->
 
 </main>
 <!-- /wp:group -->

--- a/patterns/template-search-portfolio.php
+++ b/patterns/template-search-portfolio.php
@@ -37,7 +37,7 @@
 	</div>
 	<!-- /wp:columns -->
 	
-	<!-- wp:pattern {"slug":"twentytwentyfour/posts-three-columns"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfour/posts-three-columns-images"} /-->
 </main>
 <!-- /wp:group -->
 

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -9,7 +9,7 @@
 
 	<!-- wp:query-title {"type":"archive","align":"wide","style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"var:preset|spacing|50"}}}} /-->
 
-	<!-- wp:pattern {"slug":"twentytwentyfour/archive"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfour/posts-three-columns"} /-->
 
 </main>
 <!-- /wp:group -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 	<!-- wp:heading {"level":1,"className":"screen-reader-text"} -->
 	<h1 class="wp-block-heading screen-reader-text">Posts</h1>
 	<!-- /wp:heading -->
-	<!-- wp:pattern {"slug":"twentytwentyfour/archive"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfour/posts-three-columns"} /-->
 </main>
 <!-- /wp:group -->
 

--- a/templates/search.html
+++ b/templates/search.html
@@ -27,7 +27,7 @@
 	</div>
 	<!-- /wp:columns -->
 	
-	<!-- wp:pattern {"slug":"twentytwentyfour/archive"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfour/posts-three-columns"} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

The diff of this PR is a bit confusing because it looks like we are changing the markup but in reality the only changes done here are:

- Renamed `archive.php` to `posts-three-columns.php` and updated the places where it was referenced
- Renamed `posts-three-columns.php` to `posts-three-columns-images.php` and updated the places where it was referenced

`posts-three-columns` is the pattern used by the default archive/index/search pages and `posts-three-columns-images` is used in the portfolio variants of search and archive and only show featured images.

The reason for the change is so all the query related patterns begin with `posts-` and their names are relevant to what the design of the query block looks like