### PR TITLE
Make the default home page a pattern so it can be switched back to

### DIFF
--- a/patterns/template-home-business.php
+++ b/patterns/template-home-business.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Home Template
+ * Title: Business Home Template
  * Slug: twentytwentyfour/template-home
  * Template Types: front-page, index, home
  * Viewport width: 1400

--- a/patterns/template-home-portfolio.php
+++ b/patterns/template-home-portfolio.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Portfolio Template
+ * Title: Portfolio Home Template
  * Slug: twentytwentyfour/template-home-portfolio
  * Template Types: front-page, index, home, page
  * Viewport width: 1400

--- a/patterns/template-home-writer.php
+++ b/patterns/template-home-writer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Writer Template
+ * Title: Writer Home Template
  * Slug: twentytwentyfour/template-home-writer
  * Template Types: front-page, index, home, page
  * Viewport width: 1400

--- a/patterns/template-home.php
+++ b/patterns/template-home.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Title: Home Template
+ * Slug: twentytwentyfour/template-home
+ * Template Types: front-page, index, home
+ * Viewport width: 1400
+ * Inserter: no
+ */
+?>
+
+<!-- wp:group {"style":{"position":{"type":"sticky","top":"0px"}},"layout":{"type":"default"}} -->
+<div class="wp-block-group">
+		<!-- wp:template-part {"slug":"header"} /-->
+	</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0","margin":{"top":"0"}}},"layout":{"type":"default"}} -->
+<main class="wp-block-group" style="margin-top:0">
+	<!-- wp:pattern {"slug":"twentytwentyfour/home"} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer"} /-->

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,13 +1,1 @@
-<!-- wp:group {"style":{"position":{"type":"sticky","top":"0px"}},"layout":{"type":"default"}} -->
-	<div class="wp-block-group">
-		<!-- wp:template-part {"slug":"header"} /-->
-	</div>
-<!-- /wp:group -->
-
-<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0","margin":{"top":"0"}}},"layout":{"type":"default"}} -->
-<main class="wp-block-group" style="margin-top:0">
-	<!-- wp:pattern {"slug":"twentytwentyfour/home"} /-->
-</main>
-<!-- /wp:group -->
-
-<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer"} /-->
+<!-- wp:pattern {"slug":"twentytwentyfour/template-home"} /-->


### PR DESCRIPTION
**Description**

If we land https://github.com/WordPress/gutenberg/pull/54609, we need a way for users to preview the original home template.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->
<img width="1528" alt="Screenshot 2023-09-22 at 10 38 42" src="https://github.com/WordPress/twentytwentyfour/assets/275961/7a85a36e-a7d8-4182-9dcb-fee6655781fc">

**Testing Instructions**

1. Checkout https://github.com/WordPress/gutenberg/pull/54609
2. Open the "Replace template" option
3. Confirm that you see the default template as well as the writer and portfolio ones.

**Contributors**

<!-- Please ensure anyone who contributed on linked issues and within this pull request have _AT LEAST_ their GitHub Username listed in the `CONTRIBUTORS.md` file as part of this PR. -->
