### PR TITLE
Modifying the date format at hidden-comments.php

### DIFF
--- a/patterns/hidden-comments.php
+++ b/patterns/hidden-comments.php
@@ -22,7 +22,7 @@
 				<!-- wp:group -->
 				<div class="wp-block-group">
 					<!-- wp:comment-author-name /-->
-					<!-- wp:comment-date {"format":"F j, Y - g:i a"} /-->
+					<!-- wp:comment-date /-->
 				</div>
 				<!-- /wp:group -->
 			</div>

--- a/patterns/hidden-comments.php
+++ b/patterns/hidden-comments.php
@@ -22,7 +22,7 @@
 				<!-- wp:group -->
 				<div class="wp-block-group">
 					<!-- wp:comment-author-name /-->
-					<!-- wp:comment-date {"format":"F j, Y \\a\\t g:i a"} /-->
+					<!-- wp:comment-date {"format":"F j, Y - g:i a"} /-->
 				</div>
 				<!-- /wp:group -->
 			</div>


### PR DESCRIPTION
**Description**
The date format of a comment includes a hardcoded "at" word that's used in other locales.

That's a problem while using other locales ie. in Spanish, where the `at` word doesn't exist and means nothing.

Modifying it with "-" makes it generic for all locales.

**Describe the solution you'd like**
I believe that using a `-` instead of `at` would be a saner default. Since `-` is generic and doesn't depend on the current language being used.

**Screenshots**
Before:
![image](https://github.com/WordPress/twentytwentyfour/assets/679512/fd851ef8-8f07-4ecc-9661-fbb97399c9b9)

After:
![image](https://github.com/WordPress/twentytwentyfour/assets/679512/c2cf9c91-784b-4ff3-bfd3-c45884507f09)