### PR TITLE
Use post meta template part where needed

### DIFF
--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -38,24 +38,8 @@
 	<div class="wp-block-query"><!-- wp:post-template -->
 	<!-- wp:group {"style":{"spacing":{"blockGap":"2px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 	<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"fontSize":"medium"} /-->
-
-	<!-- wp:group {"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"0.3em"}},"layout":{"type":"flex","justifyContent":"left"}} -->
-	<div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y","isLink":true} /-->
-
-	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
-	<p class="has-contrast-2-color has-text-color has-link-color">—</p>
-	<!-- /wp:paragraph -->
-
-	<!-- wp:paragraph {"fontSize":"small"} -->
-	<p class="has-small-font-size"><?php echo esc_html__( 'by', 'twentytwentyfour' ); ?></p>
-	<!-- /wp:paragraph -->
-
-	<!-- wp:post-author-name {"isLink":true} /-->
-
-	<!-- wp:post-terms {"term":"category","prefix":"in "} /--></div>
-	<!-- /wp:group --></div>
-	<!-- /wp:group --></div>
+	<!-- wp:template-part {"slug":"post-meta","theme":"twentytwentyfour"} /-->
+	</div>
 	<!-- /wp:group -->
 
 	<!-- wp:spacer {"height":"var:preset|spacing|10"} -->

--- a/patterns/page-06-writer-home.php
+++ b/patterns/page-06-writer-home.php
@@ -26,17 +26,9 @@
 
 <!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"0.22em"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y","isLink":true} /-->
+<!-- wp:template-part {"slug":"post-meta","theme":"twentytwentyfour"} /-->
 
-<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size">—</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:post-author-name {"isLink":true} /-->
-
-<!-- wp:post-terms {"term":"category","prefix":"in "} /--></div>
-<!-- /wp:group --></article>
+</article>
 <!-- /wp:group -->
 
 <!-- wp:post-excerpt {"moreText":"","excerptLength":40} /-->


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Follow up of #410 

As per [this comment](https://github.com/WordPress/twentytwentyfour/pull/410#pullrequestreview-1633662678), we are replacing the post meta with the template part where it's used