### PR TITLE
Remove Duotone

### DIFF
--- a/patterns/left-aligned-cta-image.php
+++ b/patterns/left-aligned-cta-image.php
@@ -40,7 +40,7 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:image {"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}},"className":"is-style-rounded"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:image {"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-rounded"} -->
 <figure class="wp-block-image size-full is-style-rounded"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/left-aligned-cta.webp" alt="<?php echo esc_attr__( 'An abstract Pattern Image', 'twentytwentyfour' ); ?>" style="aspect-ratio:4/3;object-fit:cover"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>


### PR DESCRIPTION
i'm just remove duotone. I took this from discussion #488
I thought it looks good so I PR it.

| Currently      | After Remove Duotone |
| ----------- | ----------- |
| <img width="1416" alt="Screenshot 2023-09-23 at 5 03 46 PM" src="https://github.com/WordPress/twentytwentyfour/assets/63150399/7acde1f5-0cf1-44d4-b677-f4cc25f8bf29"> | <img width="1433" alt="Screenshot 2023-09-23 at 5 03 03 PM" src="https://github.com/WordPress/twentytwentyfour/assets/63150399/89359777-11c2-4489-9896-7ffe0249eccb"> |
