### PR TITLE
Remove screen-reader-text class from headings

### DIFF
--- a/patterns/hidden-comments.php
+++ b/patterns/hidden-comments.php
@@ -9,9 +9,7 @@
 
 <!-- wp:comments {"className":"wp-block-comments-query-loop"} -->
 <div class="wp-block-comments wp-block-comments-query-loop">
-	<!-- wp:heading {"className":"screen-reader-text"} -->
-	<h2 class="screen-reader-text"><?php esc_html_e( 'Comments', 'twentytwentyfour' ); ?></h2>
-	<!-- /wp:heading -->
+	<!-- wp:heading --><h2><?php esc_html_e( 'Comments', 'twentytwentyfour' ); ?></h2><!-- /wp:heading -->
 	<!-- wp:comments-title {"level":3} /-->
 	<!-- wp:comment-template -->
 		<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->

--- a/patterns/template-index-portfolio.php
+++ b/patterns/template-index-portfolio.php
@@ -15,8 +15,8 @@
 
 <!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignfull">
-	<!-- wp:heading {"level":1} -->
-	<h1 class="wp-block-heading"><?php echo esc_html__( 'Posts', 'twentytwentyfour' ); ?></h1>
+	<!-- wp:heading {"level":1,"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50"}}}} -->
+	<h1 class="wp-block-heading alignwide" style="padding-top:var(--wp--preset--spacing--50)"><?php echo esc_html__( 'Posts', 'twentytwentyfour' ); ?></h1>
 	<!-- /wp:heading -->
 
 	<!-- wp:pattern {"slug":"twentytwentyfour/offset-grid-image-posts"} /-->

--- a/patterns/template-index-portfolio.php
+++ b/patterns/template-index-portfolio.php
@@ -15,8 +15,8 @@
 
 <!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignfull">
-	<!-- wp:heading {"level":1,"className="screen-reader-text} -->
-	<h1 class="wp-block-heading screen-reader-text"><?php echo esc_html__( 'Posts', 'twentytwentyfour' ); ?></h1>
+	<!-- wp:heading {"level":1} -->
+	<h1 class="wp-block-heading"><?php echo esc_html__( 'Posts', 'twentytwentyfour' ); ?></h1>
 	<!-- /wp:heading -->
 
 	<!-- wp:pattern {"slug":"twentytwentyfour/offset-grid-image-posts"} /-->

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,8 +6,8 @@
 
 <!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignfull">
-	<!-- wp:heading {"level":1} -->
-	<h1 class="wp-block-heading">Posts</h1>
+	<!-- wp:heading {"level":1,"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50"}}}} -->
+	<h1 class="wp-block-heading alignwide" style="padding-top:var(--wp--preset--spacing--50)">Posts</h1>
 	<!-- /wp:heading -->
 	<!-- wp:pattern {"slug":"twentytwentyfour/posts-three-columns"} /-->
 </main>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,8 +6,8 @@
 
 <!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignfull">
-	<!-- wp:heading {"level":1,"className":"screen-reader-text"} -->
-	<h1 class="wp-block-heading screen-reader-text">Posts</h1>
+	<!-- wp:heading {"level":1} -->
+	<h1 class="wp-block-heading">Posts</h1>
 	<!-- /wp:heading -->
 	<!-- wp:pattern {"slug":"twentytwentyfour/posts-three-columns"} /-->
 </main>


### PR DESCRIPTION
**Description**
The screen-reader-text class completely hides the block in the editor, so this can not be used to hide the block on the front.
This PR removes the class, **and does not attempt to hide the text again,** so the text will be visible.

**Screenshots**
Index:
![Index with visible H1](https://github.com/WordPress/twentytwentyfour/assets/7422055/5281bd67-5c83-4c03-86c5-e3241caee7ce)

Single post comment area:
![Visible heading above comments area](https://github.com/WordPress/twentytwentyfour/assets/7422055/c3bc28e6-50b9-4aec-925c-ac242b7e2567)


**Testing Instructions**
Test each pattern and template that had the hidden headings; comments area, index, portfolio index.
