### PR TITLE
Add aria labels to the placeholder footer navigation

### DIFF
--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -33,7 +33,7 @@
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group">
 
-<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} -->
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small","ariaLabel":"<?php esc_attr_e( 'About', 'twentytwentyfour' ); ?>"} -->
 
 <!-- wp:navigation-link {"label":"Team","url":"#"} /-->
 <!-- wp:navigation-link {"label":"History","url":"#"} /-->
@@ -54,7 +54,7 @@
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group">
 
-<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} -->
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small","ariaLabel":"<?php esc_attr_e( 'Privacy', 'twentytwentyfour' ); ?>"} -->
 
 <!-- wp:navigation-link {"label":"Privacy Policy","url":"#"} /-->
 <!-- wp:navigation-link {"label":"Terms and Conditions","url":"#"} /-->
@@ -74,7 +74,7 @@
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group">
 
-<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} -->
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small","ariaLabel":"<?php esc_attr_e( 'Social Media', 'twentytwentyfour' ); ?>"} -->
 
 <!-- wp:navigation-link {"label":"Facebook","url":"#"} /-->
 <!-- wp:navigation-link {"label":"Instagram","url":"#"} /-->


### PR DESCRIPTION
**Description**
Adds aria labels to the placeholder navigation blocks in the footer.
This helps screen reader users identify the different menus.
Requirement: https://make.wordpress.org/themes/handbook/review/accessibility/required/#aria-landmark-roles

https://github.com/WordPress/twentytwentyfour/assets/7422055/e59a0e50-34a8-4e15-85d4-98caf9853e66


**Testing Instructions**
Go to the front of the website and view the source of the footer. Confirm that the three `<nav>` elements have an aria-label that matches the heading.
