### PR TITLE
Fix colors for post-meta pattern

### DIFF
--- a/patterns/hidden-post-meta.php
+++ b/patterns/hidden-post-meta.php
@@ -14,8 +14,8 @@
 <p class="has-contrast-2-color has-text-color">—</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size"><?php echo esc_html_x( 'by', 'Prefix for the post author block: By author name', 'twentytwentyfour' ); ?></p>
+<!-- wp:paragraph {"fontSize":"small","textColor":"contrast-2"} -->
+<p class="has-small-font-size has-contrast-2-color has-text-color"><?php echo esc_html_x( 'by', 'Prefix for the post author block: By author name', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:post-author-name {"isLink":true} /-->

--- a/theme.json
+++ b/theme.json
@@ -584,7 +584,8 @@
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
-				}
+				},
+				"css":"& .wp-block-post-terms__prefix{color: var(--wp--preset--color--contrast-2);}"
 			},
 			"core/post-title": {
 				"elements": {


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Closes https://github.com/WordPress/twentytwentyfour/issues/490

This PR changes the colors of the text in this pattern. The only way to change the prefix text color was by using some CSS on theme.json, which I think it's acceptable in this case

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

<img width="512" alt="Screenshot 2023-09-25 at 11 27 12" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/2e2a59a8-b475-4b9f-9343-641167b38c2e">

@beafialho do we need to adjust something else besides the color of "by"and "in" for this pattern?
