### PR TITLE
Audit usage of locked blocks

### DIFF
--- a/templates/page-wide.html
+++ b/templates/page-wide.html
@@ -16,7 +16,7 @@
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:post-content {"lock":{"move":false,"remove":false},"layout":{"type":"constrained"}} /--></div>
+<div class="wp-block-column"><!-- wp:post-content {"lock":{"move":false,"remove":true},"layout":{"type":"constrained"}} /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
 <!-- /wp:group --></main>

--- a/templates/page-with-sidebar.html
+++ b/templates/page-with-sidebar.html
@@ -15,7 +15,7 @@
 
 		<!-- wp:column {"width":"60%"} -->
 		<div class="wp-block-column" style="flex-basis:60%">
-			<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":false},"layout":{"type":"constrained"}} -->
+			<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 			<main class="wp-block-group">
 				<!-- wp:post-title {"level":1,"fontSize":"x-large"} /-->
 

--- a/templates/single-with-sidebar.html
+++ b/templates/single-with-sidebar.html
@@ -23,7 +23,7 @@
 <!-- wp:template-part {"slug":"post-meta"} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":false},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group"><!-- wp:post-content {"lock":{"move":false,"remove":true},"layout":{"type":"constrained"}} /-->
 
 <!-- wp:post-terms {"term":"post_tag","separator":"  "} /--></main>

--- a/templates/single.html
+++ b/templates/single.html
@@ -17,7 +17,7 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"lock":{"move":false,"remove":false},"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"default"}} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"default"}} -->
 <div class="wp-block-group alignfull" style="margin-bottom:var(--wp--preset--spacing--40)">
 
 	<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->


### PR DESCRIPTION
**Description**

Closes https://github.com/WordPress/twentytwentyfour/issues/400

Removed usage of `lock` on blocks that are not the post content. Allowed post-content block to be removed