### PR TITLE
Remove break causing space at beginning of credit

### DIFF
--- a/patterns/footer-portfolio.php
+++ b/patterns/footer-portfolio.php
@@ -82,8 +82,7 @@
 			</div>
 			<!-- /wp:group -->
 			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size">
-				<?php
+			<p class="has-small-font-size"><?php
 					/* Translators: WordPress link. */
 					$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfour' ) ) . '" rel="nofollow">WordPress</a>';
 					echo sprintf(

--- a/patterns/footer-writer.php
+++ b/patterns/footer-writer.php
@@ -15,8 +15,7 @@
 <!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","justifyContent":"center"},"fontSize":"small"} /-->
 
 <!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"secondary","fontSize":"small"} -->
-<p class="has-text-align-center has-secondary-color has-text-color has-link-color has-small-font-size">
-	<?php
+<p class="has-text-align-center has-secondary-color has-text-color has-link-color has-small-font-size"><?php
 		/* Translators: WordPress link. */
 		$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfour' ) ) . '" rel="nofollow">WordPress</a>';
 		echo sprintf(

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -91,9 +91,7 @@
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"0"}}}} -->
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:0"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast-2","fontSize":"small"} -->
-<p class="has-contrast-2-color has-text-color has-link-color has-small-font-size">
-
-	<?php
+<p class="has-contrast-2-color has-text-color has-link-color has-small-font-size"><?php
 		/* Translators: WordPress link. */
 		$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfour' ) ) . '" rel="nofollow">WordPress</a>';
 		echo sprintf(


### PR DESCRIPTION
**Description**

Fixes #512 by removing the space before ' Designed'

**Screenshots**

<img width="1699" alt="Screenshot 2023-09-27 at 12 29 47 pm" src="https://github.com/WordPress/twentytwentyfour/assets/1842363/f244ab66-8edf-44f7-a76d-1db0a3cfb741">

**Questions**

The only way I found to do this was by removing the line breaks between the opening paragraph tag and the opening PHP tag. This seems like it won't fit with the coding styleguide - but I'm not sure where the space was coming from otherwise.