### PR TITLE
Remove 2024 and change copyright to &copy;

### DIFF
--- a/patterns/footer-portfolio.php
+++ b/patterns/footer-portfolio.php
@@ -76,7 +76,7 @@
 			<!-- wp:group {"style":{"spacing":{"blockGap":"6px"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 			<div class="wp-block-group">
 				<!-- wp:paragraph {"fontSize":"small"} -->
-				<p class="has-small-font-size"><?php esc_html_e( '© 2024', 'twentytwentyfour' ); ?></p>
+				<p class="has-small-font-size"><?php esc_html_e( '&copy;', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 				<!-- wp:site-title {"level":0,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} /-->
 			</div>


### PR DESCRIPTION
**Description**

Fixes #510  by removing the reference to the year.
Also changes the copyright symbol to be an html entity.