### PR TITLE
Avoid empty headings with asterisk

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -129,6 +129,14 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 					clip-path: path('M11.93.684v8.039l5.633-5.633 1.216 1.23-5.66 5.66h8.04v1.737H13.2l5.701 5.701-1.23 1.23-5.742-5.742V21h-1.737v-8.094l-5.77 5.77-1.23-1.217 5.743-5.742H.842V9.98h8.162l-5.701-5.7 1.23-1.231 5.66 5.66V.684h1.737Z');
 					display: block;
 				}
+
+				.is-style-asterisk:empty:before {
+					content: none;
+				}
+				
+				.is-style-asterisk:-moz-only-whitespace:before {
+					content: none;
+				}
 				
 				.is-style-asterisk.has-text-align-center:before {
 					margin: 0 auto;

--- a/functions.php
+++ b/functions.php
@@ -130,6 +130,7 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 					display: block;
 				}
 
+				/* Hide the asterisk if the heading has no content, to avoid using empty headings to display the asterisk only, which is an A11Y issue */
 				.is-style-asterisk:empty:before {
 					content: none;
 				}


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

I've been chatting with @scruffian about the current implementation of the asterisks and he supports that https://github.com/WordPress/twentytwentyfour/pull/449 is a better solution because with the solution on the heading block users can introduce empty hedings just to make use of the asterisk. 

This PR aims to partially fix that by hiding the asterisk on empty heading blocks. The moz prefixed rule makes it work on firefox when the user introduces whitespace in the heading too (chrome doesn't have a solution for that yet).

I would like to keep the discussion open if we feel like https://github.com/WordPress/twentytwentyfour/pull/449 is a better option for this problem. I hesitate because I think that block style in the sapcer is not a good precedent for the default theme to set regarding block styles, it feels like bending a little too much what the core block does, but I see the point that the heading solution isn't perfect either so I would like to hear what other people have to say about this.