### PR TITLE
Replace the RSVP patten with the full page RSVP landing page pattern

### DIFF
--- a/patterns/page-07-rsvp-landing.php
+++ b/patterns/page-07-rsvp-landing.php
@@ -1,9 +1,12 @@
 <?php
 /**
- * Title: RSVP
- * Slug: twentytwentyfour/rsvp
- * Categories: call-to-action, banner, featured
- * Viewport width: 1400
+ * Title: RSVP Landing Page
+ * Slug: twentytwentyfour/rsvp-landing
+ * Categories: call-to-action
+ * Keywords: page, starter
+ * Block Types: core/post-content
+ * Post Types: page, wp_template
+ * Viewport width: 1100
  */
 ?>
 
@@ -13,9 +16,9 @@
 <div class="wp-block-column is-vertically-aligned-stretch" style="flex-basis:50%"><!-- wp:group {"style":{"dimensions":{"minHeight":"100%"},"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left","verticalAlignment":"space-between"}} -->
 <div class="wp-block-group" style="min-height:100%">
 
-<!-- wp:paragraph {"align":"right","style":{"typography":{"writingMode":"vertical-rl","fontSize":"12rem","lineHeight":"1"},"spacing":{"margin":{"right":"0","left":"calc( var(--wp--preset--spacing--30) * -1)"}}},"fontFamily":"heading"} -->
-<p class="has-text-align-right has-heading-font-family" style="margin-right:0;margin-left:calc( var(--wp--preset--spacing--30) * -1);font-size:12rem;line-height:1;writing-mode:vertical-rl"><?php echo esc_html_x( 'RSVP', 'Initials for ´please respond´', 'twentytwentyfour' ); ?></p>
-<!-- /wp:paragraph -->
+<!-- wp:heading {"textAlign":"right","level":1,"style":{"typography":{"fontSize":"12rem","writingMode":"vertical-rl","lineHeight":"1"},"spacing":{"margin":{"right":"0","left":"calc( var(--wp--preset--spacing--20) * -1)"}}}} -->
+<h1 class="wp-block-heading has-text-align-right" style="margin-right:0;margin-left:calc( var(--wp--preset--spacing--20) * -1);font-size:12rem;line-height:1;writing-mode:vertical-rl"><?php echo esc_html_x( 'RSVP', 'Initials for ´please respond´', 'twentytwentyfour' ); ?></h1>
+<!-- /wp:heading -->
 
 <!-- wp:group {"layout":{"type":"constrained","contentSize":"300px","justifyContent":"left"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"style":{"layout":{"selfStretch":"fixed","flexSize":"50%"}}} -->


### PR DESCRIPTION
**Description**
This PR replaces the RSVP pattern with the RSVP landing page.

Closes https://github.com/WordPress/twentytwentyfour/issues/491

1. The file has been renamed, and the file-header updated, but the markup remains the same except for the large text.
2. The paragraph has been replaced with an H1 to improve the accessibility (which is why I labeled this as a bug fix).

![64 local_89-2_](https://github.com/WordPress/twentytwentyfour/assets/7422055/04691c11-128b-4ae4-90db-bee5f7b1d5d1)



**Testing Instructions**
This pattern works best with the "no title" page template:

1. Create a new page. 
2. In the pattern selection modal, select the RSVP pattern.
3. Do not add a title. 
4. Select the "No title" page template.
5. Save and view the page on the front.


