### PR TITLE
Add enhancements to the sidebar

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -116,6 +116,24 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 			)
 		);
 		register_block_style(
+			'core/navigation-link',
+			array(
+				'name'         => 'arrow-link',
+				'label'        => __( 'With arrow', 'twentytwentyfour' ),
+				/*
+				 * Styles for the custom arrow nav link block style
+				 */
+				'inline_style' => '
+				.is-style-arrow-link .wp-block-navigation-item__label:after {
+					content: "\2197";
+					padding-inline-start: 0.25rem;
+					vertical-align: middle;
+					text-decoration: none;
+					display: inline-block;
+				}',
+			)
+		);
+		register_block_style(
 			'core/heading',
 			array(
 				'name'         => 'asterisk',

--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -6,47 +6,50 @@
  * Inserter: no
  */
 ?>
-
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained","contentSize":"420px"}} -->
-<div class="wp-block-group">
-
-<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
-<div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"style":{"spacing":{"blockGap":"36px","padding":{"right":"0","left":"0"}}},"layout":{"type":"default"}} -->
+<div class="wp-block-group" style="padding-right:0;padding-left:0"><!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="margin-top:0;margin-bottom:0"><!-- wp:avatar {"size":80,"style":{"border":{"radius":"16px"}}} /-->
 
-<!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
+<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
 <h2 class="wp-block-heading" style="font-size:1.6rem"><?php echo esc_html__( 'About the author', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:post-author-biography {"fontSize":"small"} /--></div>
+<!-- /wp:group --></div>
 <!-- /wp:group -->
 
 <!-- wp:separator {"backgroundColor":"base-3","className":"is-style-wide"} -->
 <hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-base-3-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 
-<!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group">
-	<!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
-	<h2 class="wp-block-heading" style="font-size:1.6rem"><?php echo esc_html__( 'Latest Posts', 'twentytwentyfour' ); ?></h2>
-	<!-- /wp:heading -->
+<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
+<h2 class="wp-block-heading" style="font-size:1.6rem"><?php echo esc_html__( 'Popular Categories', 'twentytwentyfour' ); ?></h2>
+<!-- /wp:heading -->
 
-	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
-	<div class="wp-block-query"><!-- wp:post-template -->
-	<!-- wp:group {"style":{"spacing":{"blockGap":"2px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-	<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"fontSize":"medium"} /-->
-	<!-- wp:template-part {"slug":"post-meta"} /-->
-	</div>
-	<!-- /wp:group -->
+<!-- wp:categories {"showHierarchy":true,"showPostCounts":true,"fontSize":"small"} /--></div>
+<!-- /wp:group -->
 
-	<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
-	<div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
-	<!-- /wp:post-template --></div>
-	<!-- /wp:query -->
+<!-- wp:separator {"backgroundColor":"base-3","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-base-3-background-color has-background is-style-wide"/>
+<!-- /wp:separator -->
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"26px"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
+<h2 class="wp-block-heading" style="font-size:1.6rem"><?php echo esc_html__( 'Useful Links', 'twentytwentyfour' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"small"} -->
+<p class="has-small-font-size"><?php echo esc_html__( 'Links I found useful and wanted to share.', 'twentytwentyfour' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"spacing":{"blockGap":"var:preset|spacing|10"}},"fontSize":"small"} -->
+<!-- wp:navigation-link {"label":"<?php echo esc_html__( 'Latest inflation report', 'twentytwentyfour' ); ?>","url":"#","className":"is-style-arrow-link","style":{"typography":{"textDecoration":"underline"}}} /-->
+<!-- wp:navigation-link {"label":"<?php echo esc_html__( 'Financial apps for families', 'twentytwentyfour' ); ?>","url":"#","className":"is-style-arrow-link","style":{"typography":{"textDecoration":"underline"}}} /-->
+<!-- /wp:navigation -->
 </div>
 <!-- /wp:group -->
 
@@ -54,21 +57,15 @@
 <hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-base-3-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 
-<!-- wp:group {"layout":{"type":"constrained"}} -->
+<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 <div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
-<h2 class="wp-block-heading" style="font-size:1.6rem"><?php echo esc_html__( 'Links', 'twentytwentyfour' ); ?></h2>
+<h2 class="wp-block-heading" style="font-size:1.6rem"><?php echo esc_html__( 'Search the website', 'twentytwentyfour' ); ?></h2>
 <!-- /wp:heading -->
 
-
-<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400","textDecoration":"underline"}},"fontSize":"small"} -->
-<!-- wp:navigation-link {"label":"<?php echo esc_html__( 'Latest inflation report', 'twentytwentyfour' ); ?>","url":"#"} /-->
-<!-- wp:navigation-link {"label":"<?php echo esc_html__( 'Financial apps for families', 'twentytwentyfour' ); ?>","url":"#"} /-->
-<!-- /wp:navigation --></div>
+<!-- wp:search {"label":"<?php echo esc_attr_x( 'Search', 'search form label', 'twentytwentyfour' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Search...', 'search form placeholder', 'twentytwentyfour' ); ?>","width":100,"widthUnit":"%","buttonText":"<?php echo esc_attr_x( 'Search', 'search form label', 'twentytwentyfour' ); ?>"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:spacer {"height":"var:preset|spacing|10"} -->
 <div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-</div>
+<!-- /wp:spacer --></div>
 <!-- /wp:group -->

--- a/theme.json
+++ b/theme.json
@@ -319,6 +319,15 @@
 					"blockGap": "0.7rem"
 				}
 			},
+			"core/categories": {
+				"spacing": {
+					"padding": {
+						"left": "0px",
+						"right": "0px"
+					}
+				},
+				"css": "& {list-style-type:none;} & li{margin-bottom: 0.5rem;}"
+			},
 			"core/code": {
 				"border": {
 					"color": "var(--wp--preset--color--contrast)",


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Closes https://github.com/WordPress/twentytwentyfour/issues/528

This adds the enhancements from the linked PR above and adds a block style for the nav link to add the arrows to be used when linking externally. This also adds styling for the categories blocks to remove the dots.
Please refer to the linked PR for the discussion on preset usage for this particular pattern.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

Desktop | Mobile
--- | ---
<img width="1338" alt="Screenshot 2023-10-02 at 11 17 14" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/5313150f-ed69-4879-aa57-def07c258c47"> | <img width="530" alt="Screenshot 2023-10-02 at 11 17 32" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/0ca65c92-5996-4ef3-96b7-844cb946456f">

/cc @beafialho