### PR TITLE
Fix border color of buttons on hover

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -789,6 +789,9 @@
 						"offset": "2px",
 						"style": "dotted",
 						"width": "1px"
+					},
+					"border": {
+						"color": "var(--wp--preset--color--contrast-2)"
 					}
 				},
 				":hover": {

--- a/theme.json
+++ b/theme.json
@@ -795,6 +795,9 @@
 					"color": {
 						"background": "var(--wp--preset--color--contrast-2)",
 						"text": "var(--wp--preset--color--base)"
+					},
+					"border": {
+						"color": "var(--wp--preset--color--contrast-2)"
 					}
 				},
 				"border": {


### PR DESCRIPTION


**Description**

<!-- Describe the purpose or reason for the pull request -->
Alternative to https://github.com/WordPress/twentytwentyfour/pull/526
Closes https://github.com/WordPress/twentytwentyfour/issues/520

Fixes the color of the border so it's not noticeable on hover or focus

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

![Screen Capture on 2023-10-02 at 16-51-39(1)](https://github.com/WordPress/twentytwentyfour/assets/3593343/74506685-baf8-44c4-8a72-3db08f99517f)
