### PR TITLE
Fix incorrect block style path declaration

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -33,20 +33,11 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 			'core/button',
 			array(
 				'handle' => 'twentytwentyfour-button-style-outline',
-				'src'    => get_template_directory_uri() . '/assets/css/button-outline.css',
+				'src'    => get_theme_file_uri( 'assets/css/button-outline.css' ),
 				'ver'    => wp_get_theme()->get( 'Version' ),
+				'path'   => get_theme_file_path( 'assets/css/button-outline.css' ),
 			)
 		);
-
-		/**
-		 * Add the `path` data to our stylesheet.
-		 *
-		 * This will let WordPress determine the best loading strategy for the stylesheet:
-		 * Small stylesheets will get inlined, while larger stylesheets will be loaded separately.
-		 *
-		 * See https://make.wordpress.org/core/2021/07/01/block-styles-loading-enhancements-in-wordpress-5-8/#inlining-small-assets for more info.
-		 */
-		wp_style_add_data( 'twentytwentyfour-button-style-outline', 'path', get_theme_file_path( 'assets/css/button-outline.css' ) );
 
 		register_block_style(
 			'core/details',
@@ -63,11 +54,11 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 					padding-bottom: var(--wp--preset--spacing--10);
 					border-bottom: 1px solid rgba(255, 255, 255, 0.20);
 				}
-				
+
 				.is-style-arrow-icon-details summary {
 					list-style-type: "\2193\00a0\00a0\00a0";
 				}
-				
+
 				.is-style-arrow-icon-details[open]>summary {
 					list-style-type: "\2192\00a0\00a0\00a0";
 				}',
@@ -90,7 +81,7 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 					padding: 0.375rem 0.875rem;
 					border-radius: var(--wp--preset--spacing--20);
 				}
-				
+
 				.is-style-pill a:hover {
 					background-color: var(--wp--preset--color--contrast-3);
 				}',
@@ -109,7 +100,7 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				ul.is-style-checkmark-list {
 					list-style-type: "\2713";
 				}
-				
+
 				ul.is-style-checkmark-list li {
 					padding-inline-start: 1ch;
 				}',
@@ -152,19 +143,19 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				.is-style-asterisk:empty:before {
 					content: none;
 				}
-				
+
 				.is-style-asterisk:-moz-only-whitespace:before {
 					content: none;
 				}
-				
+
 				.is-style-asterisk.has-text-align-center:before {
 					margin: 0 auto;
 				}
-				
+
 				.is-style-asterisk.has-text-align-right:before {
 					margin-left: auto;
 				}
-				
+
 				.rtl .is-style-asterisk.has-text-align-left:before {
 					margin-right: auto;
 				}",


### PR DESCRIPTION
**Description**

This fixes https://core.trac.wordpress.org/ticket/59466.

Also see previous core PR https://github.com/WordPress/wordpress-develop/pull/5321 for additional context.

The PR also fixes tabs in empty lines, which per WordPress Coding Standards should not be present.

**Testing Instructions**

See https://core.trac.wordpress.org/ticket/59466#comment:2

**Contributors**

`felixarntz` / `flixos90` (added to `CONTRIBUTORS.md`)
