### PR TITLE
Update version on readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Twenty Twenty-Four ===
 Contributors: wordpressdotorg
-Requires at least: 6.2
+Requires at least: 6.4
 Tested up to: 6.4
 Requires PHP: 7.0
 License: GPLv2 or later


### PR DESCRIPTION
i update on readme.txt Requires at least: 6.2 to 6.4 for match style.css and readme.txt [check](https://github.com/WordPress/twentytwentyfour/blob/be827b8e3a5932191511c033d73a2898e110bed5/style.css#L7)