### PR TITLE
Exclude Button blocks with custom Text color from Outline hover style

### DIFF
--- a/assets/css/button-outline.css
+++ b/assets/css/button-outline.css
@@ -1,5 +1,5 @@
 .wp-block-button.is-style-outline
-	> .wp-block-button__link:not(.has-background):hover {
+	> .wp-block-button__link:not(.has-text-color, .has-background):hover {
 	background-color: var(--wp--preset--color--contrast-2);
 	color: var(--wp--preset--color--base);
 	border-color: var(--wp--preset--color--contrast-2);


### PR DESCRIPTION
**Description**

The Outline style's hover colors do not apply when a user selects a Background color, but those theme colors do apply when using a custom Text color (without a background). The gray background is probably not often appropriate with special text colors either.

**Testing Instructions**

1. Activate the theme.
2. Create a post.
3. Add Button blocks with various Text and Background color options. You could paste [the blocks I made](https://gist.github.com/sabernhardt/9934df61363fe27c07736e4bcfa0101e).
4. View the post and hover the (mouse) cursor over each link.

Also use the tab key to advance to each link, to determine whether the hover style should apply to both hover and focus states.
