### PR TITLE
Fixed Pulloquote Block border issue

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -612,23 +612,9 @@
 			},
 			"core/pullquote": {
 				"border": {
-					"bottom": {
-						"style": "solid",
-						"width": "1px"
-					},
-					"left": {
-						"style": "solid",
-						"width": "1px"
-					},
 					"radius": "var(--wp--preset--spacing--20)",
-					"right": {
-						"style": "solid",
-						"width": "1px"
-					},
-					"top": {
-						"style": "solid",
-						"width": "1px"
-					}
+					"style": "solid",
+					"width": "1px"
 				},
 				"elements": {
 					"cite": {

--- a/theme.json
+++ b/theme.json
@@ -612,8 +612,7 @@
 			},
 			"core/pullquote": {
 				"border": {
-					"radius": "var(--wp--preset--spacing--20)",
-					"style": "solid"
+					"radius": "var(--wp--preset--spacing--20)"
 				},
 				"elements": {
 					"cite": {

--- a/theme.json
+++ b/theme.json
@@ -613,21 +613,21 @@
 			"core/pullquote": {
 				"border": {
 					"bottom": {
-						"style": "none",
-						"width": "0px"
+						"style": "solid",
+						"width": "1px"
 					},
 					"left": {
-						"style": "none",
-						"width": "0px"
+						"style": "solid",
+						"width": "1px"
 					},
 					"radius": "var(--wp--preset--spacing--20)",
 					"right": {
-						"style": "none",
-						"width": "0px"
+						"style": "solid",
+						"width": "1px"
 					},
 					"top": {
-						"style": "none",
-						"width": "0px"
+						"style": "solid",
+						"width": "1px"
 					}
 				},
 				"elements": {

--- a/theme.json
+++ b/theme.json
@@ -613,8 +613,7 @@
 			"core/pullquote": {
 				"border": {
 					"radius": "var(--wp--preset--spacing--20)",
-					"style": "solid",
-					"width": "1px"
+					"style": "solid"
 				},
 				"elements": {
 					"cite": {


### PR DESCRIPTION
**Description**

Hello Team,

I have worked on issue #533 and resolved it from my end. Here, I have added my PR.

**Screenshots**

**Back-end**
![backend](https://github.com/WordPress/twentytwentyfour/assets/53076293/96fd1b3f-f908-4210-b1f4-73016de7462d)

**Front-end**
![frontend](https://github.com/WordPress/twentytwentyfour/assets/53076293/dc2eac85-1424-4a0d-9454-a7df8d3d66c0)


**Testing Instructions**

- Go to page Type / to choose a block
- Select "Pullquote" block
- Add dummy text
- Click on the block setting and try to set the border.

**Contributors**

<!-- Please ensure anyone who contributed on linked issues and within this pull request have _AT LEAST_ their GitHub Username listed in the `CONTRIBUTORS.md` file as part of this PR. -->
