### PR TITLE
Remove setCascadingProperties from nav block

### DIFF
--- a/parts/header.html
+++ b/parts/header.html
@@ -8,6 +8,6 @@
 	<!-- /wp:group --></div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}}} /--></div>
+	<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}}} /--></div>
 	<!-- /wp:group --></div>
 	<!-- /wp:group -->


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->
Removes the deprecated attribute and closes https://github.com/WordPress/twentytwentyfour/issues/554

The navigation should still work as intended