### PR TITLE
Remove static colors in favor of presets

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -52,7 +52,7 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				.is-style-arrow-icon-details {
 					padding-top: var(--wp--preset--spacing--10);
 					padding-bottom: var(--wp--preset--spacing--10);
-					border-bottom: 1px solid rgba(255, 255, 255, 0.20);
+					border-bottom: 1px solid var(--wp--preset--color--contrast-2);
 				}
 
 				.is-style-arrow-icon-details summary {

--- a/functions.php
+++ b/functions.php
@@ -52,7 +52,7 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				.is-style-arrow-icon-details {
 					padding-top: var(--wp--preset--spacing--10);
 					padding-bottom: var(--wp--preset--spacing--10);
-					border-bottom: 1px solid var(--wp--preset--color--contrast-2);
+					border-bottom: 1px solid var(--wp--preset--color--contrast-2, currentColor);
 				}
 
 				.is-style-arrow-icon-details summary {

--- a/patterns/faq.php
+++ b/patterns/faq.php
@@ -13,8 +13,8 @@
 <!-- /wp:heading -->
 
 <!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
-<div class="wp-block-group alignwide"><!-- wp:separator {"style":{"color":{"background":"#ffffff1a"}},"className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background is-style-wide" style="background-color:#ffffff1a;color:#ffffff1a"/>
+<div class="wp-block-group alignwide"><!-- wp:separator {"backgroundColor":"contrast-2","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-contrast-2-color has-alpha-channel-opacity has-contrast-2-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 
 <!-- wp:details {"style":{"spacing":{"margin":{"top":"0"}}},"className":"is-style-arrow-icon-details","fontSize":"medium"} -->


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Closes https://github.com/WordPress/twentytwentyfour/issues/417

This PR removes the static colors from the FAQ pattern and associated block style in favor of presets. The color is not the exact same as the figma but it's quite close. This makes it work on the style variations too.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

<img width="1518" alt="Screenshot 2023-10-04 at 10 15 00" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/8bcb99c9-a213-4fa2-a861-bf59202a5152">

<img width="1492" alt="Screenshot 2023-10-04 at 10 14 54" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/44967fe2-8008-4291-acf8-e02e137260ca">

