### PR TITLE
Single posts: fix padding on mobile

### DIFF
--- a/templates/single.html
+++ b/templates/single.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
+<!-- wp:group {"tagName":"main","align":"full"} -->
 <main class="wp-block-group alignfull"><!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50"},"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--50)"><!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
 
@@ -13,16 +13,10 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"default"}} -->
-<div class="wp-block-group alignfull" style="margin-bottom:var(--wp--preset--spacing--40)">
+<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
 
-	<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
-		
-</div>
-<!-- /wp:group -->
-
-<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)">
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"},"padding":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50)">
 	<!-- wp:post-terms {"term":"post_tag","separator":"  ","className":"is-style-pill"} /-->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Closes https://github.com/WordPress/twentytwentyfour/issues/421

This PR fixes the markup of this template so we have padding on the sides of the post content while maintaining the ability to add wide and full width aligned blocks on desktop

**Screenshots**

<!-- Add screenshots of the change, if applicable -->
<img width="360" alt="Screenshot 2023-10-04 at 10 28 27" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/f19baef1-aafd-4e76-8190-1ada393742ff">
<img width="1399" alt="Screenshot 2023-10-04 at 10 28 19" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/fb645672-bbe3-465c-a73b-7b1998e7a703">

