### PR TITLE
Rust varition: fixes for missing colors

### DIFF
--- a/assets/css/button-outline.css
+++ b/assets/css/button-outline.css
@@ -1,6 +1,6 @@
 .wp-block-button.is-style-outline
 	> .wp-block-button__link:not(.has-background):hover {
-	background-color: var(--wp--preset--color--contrast-2);
+	background-color: var(--wp--preset--color--contrast-2, var(--wp--preset--color--contrast, transparent));
 	color: var(--wp--preset--color--base);
-	border-color: var(--wp--preset--color--contrast-2);
+	border-color: var(--wp--preset--color--contrast-2, var(--wp--preset--color--contrast, currentColor));
 }

--- a/styles/rust.json
+++ b/styles/rust.json
@@ -91,5 +91,89 @@
 				}
 			]
 		}
+	},
+	"styles": {
+		"blocks": {
+			"core/comment-date": {
+				"color": {
+					"text": "var(--wp--preset--color--contrast)"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--contrast)"
+						}
+					}
+				}
+			},
+			"core/comment-edit-link": {
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--contrast)"
+						}
+					}
+				}
+			},
+			"core/comment-reply-link": {
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--contrast)"
+						}
+					}
+				}
+			},
+			"core/post-date": {
+				"color": {
+					"text": "var(--wp--preset--color--contrast)"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--contrast)"
+						}
+					}
+				}
+			},
+			"core/post-terms": {
+				"css":"& .wp-block-post-terms__prefix{color: var(--wp--preset--color--contrast);}"
+			},
+			"core/quote": {
+				"color": {
+					"background": "var(--wp--preset--color--base)"
+				}
+			},
+			"core/site-tagline": {
+				"color": {
+					"text": "var(--wp--preset--color--contrast)"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				":focus": {
+					"color": {
+						"background": "var(--wp--preset--color--contrast)"
+					},
+					"border": {
+						"color": "var(--wp--preset--color--contrast)"
+					}
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--contrast)"
+					},
+					"border": {
+						"color": "var(--wp--preset--color--contrast)"
+					}
+				}
+			},
+			"caption": {
+				"color": {
+					"text": "var(--wp--preset--color--contrast)"
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Rust only defines 3 colors and we have a few places where the undefined colors are used. This PR assigns new colors in those instances so we keep everything visible and contrasting.

Closes https://github.com/WordPress/twentytwentyfour/issues/480

