### PR TITLE
Aligns the core/code block border radius with core/image and core/quote blocks

### DIFF
--- a/styles/ice.json
+++ b/styles/ice.json
@@ -30,7 +30,7 @@
 						"style": "none",
 						"width": "0px"
 					},
-					"radius": "16px",
+					"radius": "var(--wp--preset--spacing--20)",
 					"right": {
 						"style": "none",
 						"width": "0px"

--- a/styles/ice.json
+++ b/styles/ice.json
@@ -20,38 +20,6 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/code": {
-				"border": {
-					"bottom": {
-						"style": "none",
-						"width": "0px"
-					},
-					"left": {
-						"style": "none",
-						"width": "0px"
-					},
-					"radius": "var(--wp--preset--spacing--20)",
-					"right": {
-						"style": "none",
-						"width": "0px"
-					},
-					"top": {
-						"style": "none",
-						"width": "0px"
-					}
-				},
-				"color": {
-					"background": "var(--wp--preset--color--base-2)",
-					"text": "var(--wp--preset--color--contrast-2)"
-				},
-				"elements": {
-					"link": {
-						"color": {
-							"text": "var(--wp--preset--color--contrast-2)"
-						}
-					}
-				}
-			},
 			"core/pullquote": {
 				"border": {
 					"bottom": {

--- a/theme.json
+++ b/theme.json
@@ -331,20 +331,25 @@
 			"core/code": {
 				"border": {
 					"color": "var(--wp--preset--color--contrast)",
-					"radius": "var(--wp--preset--spacing--20)",
-					"style": "solid",
-					"width": "2px"
+					"radius": "var(--wp--preset--spacing--20)"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--base-2)",
+					"text": "var(--wp--preset--color--contrast-2)"
 				},
 				"spacing": {
 					"padding": {
-						"bottom": "var(--wp--preset--spacing--50)",
-						"left": "var(--wp--preset--spacing--50)",
-						"right": "var(--wp--preset--spacing--50)",
-						"top": "var(--wp--preset--spacing--50)"
+						"bottom": "calc(var(--wp--preset--spacing--30) + 0.75rem)",
+						"left": "calc(var(--wp--preset--spacing--30) + 0.75rem)",
+						"right": "calc(var(--wp--preset--spacing--30) + 0.75rem)",
+						"top": "calc(var(--wp--preset--spacing--30) + 0.75rem)"
 					}
 				},
 				"typography": {
-					"fontFamily": "monospace"
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontStyle": "normal",
+					"fontWeight": "400",
+					"lineHeight": "1.6"
 				}
 			},
 			"core/comment-author-name": {

--- a/theme.json
+++ b/theme.json
@@ -331,7 +331,7 @@
 			"core/code": {
 				"border": {
 					"color": "var(--wp--preset--color--contrast)",
-					"radius": "0.25rem",
+					"radius": "var(--wp--preset--spacing--20)",
 					"style": "solid",
 					"width": "2px"
 				},


### PR DESCRIPTION
**Description**

In https://github.com/WordPress/twentytwentyfour/issues/519, it was reported that the block border radius for `core/code` blocks did not match the `core/image` and `core/quote` blocks as per the Figma design. This PR fixes that. I've also made sure the Figma design is followed. I've removed the override in `styles/ice.json` as that did not change any of the styling anymore.

I kept the font family as it was in the default theme. I see Figma uses `SF Mono`, if we need to add that, perhaps it's better to do that in a separate PR?

**Screenshots**

![Screenshot 2023-10-06 at 16 16 25](https://github.com/WordPress/twentytwentyfour/assets/7521233/2aa3cd0e-8f03-4605-910f-97f8b13cb405)

**Testing Instructions**

1. Activate the theme. 
2. Create a new post. 
3. Add a code block, a quote block, and an image block. Set the image to be rounded.
4. Confirm the border radius of all of these blocks is the same.
5. In the site editor, set "icy" as your default theme.
6. Publish your post and check it in the front-end.
7. Confirm the code block still has the correct border radius. 

**Contributors**

@mhkuu 

Contributed during **Yoast Contributor Day** on Wednesday 4 October 2023.

<!-- Please ensure anyone who contributed on linked issues and within this pull request have _AT LEAST_ their GitHub Username listed in the `CONTRIBUTORS.md` file as part of this PR. -->

Fixes https://github.com/WordPress/twentytwentyfour/issues/519.
