### PR TITLE
Add missing H1 headings

### DIFF
--- a/patterns/hero.php
+++ b/patterns/hero.php
@@ -9,8 +9,8 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained","contentSize":"","wideSize":""}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
-<div class="wp-block-group"><!-- wp:heading {"textAlign":"center"} -->
-<h2 class="wp-block-heading has-text-align-center"><?php echo esc_html_x( 'A commitment to innovation and sustainability', 'Heading of the hero section', 'twentytwentyfour' ); ?></h2>
+<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","fontSize":"x-large","level":1} -->
+<h1 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html_x( 'A commitment to innovation and sustainability', 'Heading of the hero section', 'twentytwentyfour' ); ?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->

--- a/patterns/hidden-hidden-intro-text-left.php
+++ b/patterns/hidden-hidden-intro-text-left.php
@@ -17,9 +17,7 @@
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"70%"} -->
 <div class="wp-block-column" style="flex-basis:70%">
 
-<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"xx-large","fontFamily":"heading"} -->
-<p class="has-heading-font-family has-xx-large-font-size" style="line-height:1.2"><?php echo wp_kses_post( __( 'I’m <em>Leia Acosta</em>, a passionate photographer who finds inspiration in capturing the fleeting beauty of life.' ) ); ?></p>
-<!-- /wp:paragraph -->
+<!-- wp:heading {"level":1,"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"xx-large"} --><h1 class="wp-block-heading has-xx-large-font-size" style="line-height:1.2"><?php echo wp_kses_post( __( 'I’m <em>Leia Acosta</em>, a passionate photographer who finds inspiration in capturing the fleeting beauty of life.' ) ); ?></h1><!-- /wp:heading -->
 
 </div>
 <!-- /wp:column -->

--- a/patterns/text-centered-title.php
+++ b/patterns/text-centered-title.php
@@ -8,8 +8,10 @@
 ?>
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained","contentSize":"800px"}} -->
-<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:paragraph {"align":"center","style":{"typography":{"lineHeight":"1.2","fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-large","fontFamily":"heading"} -->
-<p class="has-text-align-center has-heading-font-family has-x-large-font-size" style="font-style:normal;font-weight:400;line-height:1.2"><em>
+<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
+
+<!-- wp:heading {"textAlign":"center","level":1,"fontSize":"x-large","level":1} -->
+<h1 class="wp-block-heading has-text-align-center has-x-large-font-size"><em>
 <?php
 	/* Translators: About link placeholder */
 	$about_link = '<a href="#" rel="nofollow">' . esc_html__( 'Money Studies', 'twentytwentyfour' ) . '</a>';
@@ -19,7 +21,6 @@
 		$about_link
 	);
 	?>
-
-</em></p>
-<!-- /wp:paragraph --></div>
+</em></h1>
+<!-- /wp:heading --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
**Description**
For https://github.com/WordPress/twentytwentyfour/issues/3

The PR solves the following:

H1 is missing on the default home template
H1 is missing on the writer home template
H1 is missing from the portfolio home template

In some templates this means replacing paragraphs with H1 headings, which means that I removed the font family and in one case, the line height. Kindly review that the text still matches the wanted design.

**Testing Instructions**
View the templates listed above.  Confirm that the template has an H1 heading.
Confirm that the style of the text is correct.
