### PR TITLE
Update the 'no results' pattern text and position.

### DIFF
--- a/patterns/hidden-no-results-content.php
+++ b/patterns/hidden-no-results-content.php
@@ -6,5 +6,5 @@
  */
 ?>
 <!-- wp:paragraph -->
-<p><?php echo esc_html_x( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfour' ); ?></p>
+<p><?php echo esc_html_x( 'No posts were found.', 'Message explaining that there are no results returned from a search', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->

--- a/patterns/posts-one-column.php
+++ b/patterns/posts-one-column.php
@@ -9,6 +9,10 @@
 
 <!-- wp:query {"query":{"perPage":3,"pages":0,"offset":"0","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"full","layout":{"type":"constrained"}} -->
 <div class="wp-block-query alignfull">
+	<!-- wp:query-no-results -->
+		<!-- wp:pattern {"slug":"twentytwentyfour/no-results-content"} /-->
+	<!-- /wp:query-no-results -->
+
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"0","right":"0"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:0">
 		<!-- wp:post-template {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"default","columnCount":3}} -->
@@ -31,9 +35,7 @@
 		<!-- wp:query-pagination-previous /-->
 		<!-- wp:query-pagination-next /-->
 		<!-- /wp:query-pagination -->
-		<!-- wp:query-no-results -->
-			<!-- wp:pattern {"slug":"twentytwentyfour/no-results-content"} /-->
-		<!-- /wp:query-no-results -->
+
 	</div>
 	<!-- /wp:group -->
 </div>

--- a/patterns/posts-three-columns-images.php
+++ b/patterns/posts-three-columns-images.php
@@ -10,12 +10,12 @@
 
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":"0","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"wide","layout":{"type":"default"}} -->
 <div class="wp-block-query alignwide">
+	<!-- wp:query-no-results -->
+		<!-- wp:pattern {"slug":"twentytwentyfour/no-results-content"} /-->
+	<!-- /wp:query-no-results -->
+
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"0","right":"0"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:0">
-
-		<!-- wp:query-no-results -->
-			<!-- wp:pattern {"slug":"twentytwentyfour/no-results-content"} /-->
-		<!-- /wp:query-no-results -->
 
 		<!-- wp:post-template {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"grid","columnCount":3}} -->
 			<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/4","style":{"spacing":{"margin":{"bottom":"0"},"padding":{"bottom":"var:preset|spacing|20"}}}} /-->

--- a/patterns/posts-three-columns-images.php
+++ b/patterns/posts-three-columns-images.php
@@ -13,6 +13,10 @@
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"0","right":"0"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:0">
 
+		<!-- wp:query-no-results -->
+			<!-- wp:pattern {"slug":"twentytwentyfour/no-results-content"} /-->
+		<!-- /wp:query-no-results -->
+
 		<!-- wp:post-template {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"grid","columnCount":3}} -->
 			<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/4","style":{"spacing":{"margin":{"bottom":"0"},"padding":{"bottom":"var:preset|spacing|20"}}}} /-->
 		<!-- /wp:post-template -->
@@ -25,10 +29,6 @@
 		<!-- wp:query-pagination-previous /-->
 		<!-- wp:query-pagination-next /-->
 		<!-- /wp:query-pagination -->
-
-		<!-- wp:query-no-results -->
-			<!-- wp:pattern {"slug":"twentytwentyfour/no-results-content"} /-->
-		<!-- /wp:query-no-results -->
 
 	</div>
 	<!-- /wp:group -->

--- a/patterns/posts-three-columns.php
+++ b/patterns/posts-three-columns.php
@@ -12,6 +12,9 @@
 <div class="wp-block-query alignwide">
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"0","right":"0"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:0">
+		<!-- wp:query-no-results -->
+			<!-- wp:pattern {"slug":"twentytwentyfour/no-results-content"} /-->
+		<!-- /wp:query-no-results -->
 
 		<!-- wp:post-template {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"grid","columnCount":3}} -->
 
@@ -41,10 +44,6 @@
 		<!-- wp:query-pagination-previous /-->
 		<!-- wp:query-pagination-next /-->
 		<!-- /wp:query-pagination -->
-
-		<!-- wp:query-no-results -->
-			<!-- wp:pattern {"slug":"twentytwentyfour/no-results-content"} /-->
-		<!-- /wp:query-no-results -->
 
 	</div>
 	<!-- /wp:group -->

--- a/patterns/posts-three-columns.php
+++ b/patterns/posts-three-columns.php
@@ -10,11 +10,12 @@
 
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":"0","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"wide","layout":{"type":"default"}} -->
 <div class="wp-block-query alignwide">
+	<!-- wp:query-no-results -->
+		<!-- wp:pattern {"slug":"twentytwentyfour/no-results-content"} /-->
+	<!-- /wp:query-no-results -->
+
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"0","right":"0"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:0">
-		<!-- wp:query-no-results -->
-			<!-- wp:pattern {"slug":"twentytwentyfour/no-results-content"} /-->
-		<!-- /wp:query-no-results -->
 
 		<!-- wp:post-template {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"grid","columnCount":3}} -->
 

--- a/theme.json
+++ b/theme.json
@@ -641,6 +641,13 @@
 			"core/query-title": {
 				"css": "& span {font-style: italic;}"
 			},
+			"core/query-no-results": {
+				"spacing": {
+					"padding": {
+						"top": "var(--wp--preset--spacing--30)"
+					}
+				}
+			},
 			"core/quote": {
 				"border": {
 					"radius": "var(--wp--preset--spacing--20)"


### PR DESCRIPTION
**Description**
For https://github.com/WordPress/twentytwentyfour/issues/566

Updates the text of the no results pattern to "No posts were found".
Moves the pattern higher up in the template, so that it is not pushed down by the post template spacing.


The archive and search uses the same pattern, so I did not try to have different spacing for the two templates.
- In Figma, the search page has 100px spacing between the form and the no results text, and in archives it is 40px between the title and the no results text.
- As a compromise I used preset 30, (2.5 rem 40px) and I added it in theme.json. This can of course be adjusted and moved to the pattern or templates.

**Screenshots**

Search, after:
![64 local__s=wolves](https://github.com/WordPress/twentytwentyfour/assets/7422055/dc55739f-76c3-48ac-a7da-79065c23240b)

Archive, after:
![64 local_tag_chattels_ (1)](https://github.com/WordPress/twentytwentyfour/assets/7422055/eccda665-4ae5-4010-9850-786443481224)




**Testing Instructions**
View a search and archive page that has no result. 
To view a tag or category with no result, you can go to admin > posts > tags and see a list of tags that has 0 entries. You may need to create one if there are none.
