### PR TITLE
Hidden patterns should use false instead of no for the inserter property

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ We do this for patterns we don't want the user to access via the inserter or the
 
 We do this by adding the following line:
 
-` * Inserter: no`
+` * Inserter: false`
 
 Let's prefix hidden patterns using `hidden-` when we name the pattern file.
 

--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -2,7 +2,7 @@
 /**
  * Title: A 404 page
  * Slug: twentytwentyfour/404
- * Inserter: no
+ * Inserter: false
  */
 ?>
 

--- a/patterns/hidden-comments.php
+++ b/patterns/hidden-comments.php
@@ -2,7 +2,7 @@
 /**
  * Title: Comments
  * slug: twentytwentyfour/comments
- * inserter: no
+ * Inserter: false
  */
 ?>
 

--- a/patterns/hidden-full-screen-image.php
+++ b/patterns/hidden-full-screen-image.php
@@ -2,7 +2,7 @@
 /**
  * Title: Full Screen Image
  * Slug: twentytwentyfour/full-screen-image
- * Inserter: no
+ * Inserter: false
  */
 ?>
 

--- a/patterns/hidden-hidden-intro-text-left.php
+++ b/patterns/hidden-hidden-intro-text-left.php
@@ -3,7 +3,7 @@
  * Title: Heading on left
  * Slug: twentytwentyfour/intro-text-left
  * Categories: text
- * Inserter: no
+ * Inserter: false
  */
 ?>
 

--- a/patterns/hidden-no-results-content.php
+++ b/patterns/hidden-no-results-content.php
@@ -2,7 +2,7 @@
 /**
  * Title: Hidden No Results Content
  * Slug: twentytwentyfour/no-results-content
- * Inserter: no
+ * Inserter: false
  */
 ?>
 <!-- wp:paragraph -->

--- a/patterns/hidden-post-meta.php
+++ b/patterns/hidden-post-meta.php
@@ -2,7 +2,7 @@
 /**
  * Title: Post Meta
  * slug: twentytwentyfour/post-meta
- * inserter: no
+ * Inserter: false
  */
 ?>
 

--- a/patterns/hidden-search.php
+++ b/patterns/hidden-search.php
@@ -2,7 +2,7 @@
 /**
  * Title: Hidden Search form
  * Slug: twentytwentyfour/search
- * Inserter: no
+ * Inserter: false
  */
 ?>
 

--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -3,7 +3,7 @@
  * Title: sidebar
  * Slug: twentytwentyfour/sidebar
  * Categories: hidden
- * Inserter: no
+ * Inserter: false
  */
 ?>
 <!-- wp:group {"style":{"spacing":{"blockGap":"36px","padding":{"right":"0","left":"0"}}},"layout":{"type":"default"}} -->

--- a/patterns/template-archive-portfolio.php
+++ b/patterns/template-archive-portfolio.php
@@ -4,7 +4,7 @@
  * Slug: twentytwentyfour/template-archive-portfolio
  * Template Types: archive
  * Viewport width: 1400
- * Inserter: no
+ * Inserter: false
  */
 ?>
 

--- a/patterns/template-archive-writer.php
+++ b/patterns/template-archive-writer.php
@@ -4,7 +4,7 @@
  * Slug: twentytwentyfour/template-archive-writer
  * Template Types: archive, category, tag, author, date
  * Viewport width: 1400
- * Inserter: no
+ * Inserter: false
  */
 ?>
 

--- a/patterns/template-home-business.php
+++ b/patterns/template-home-business.php
@@ -4,7 +4,7 @@
  * Slug: twentytwentyfour/template-home
  * Template Types: front-page, index, home
  * Viewport width: 1400
- * Inserter: no
+ * Inserter: false
  */
 ?>
 

--- a/patterns/template-home-portfolio.php
+++ b/patterns/template-home-portfolio.php
@@ -4,7 +4,7 @@
  * Slug: twentytwentyfour/template-home-portfolio
  * Template Types: front-page, index, home, page
  * Viewport width: 1400
- * Inserter: no
+ * Inserter: false
  */
 ?>
 

--- a/patterns/template-home-writer.php
+++ b/patterns/template-home-writer.php
@@ -4,7 +4,7 @@
  * Slug: twentytwentyfour/template-home-writer
  * Template Types: front-page, index, home, page
  * Viewport width: 1400
- * Inserter: no
+ * Inserter: false
  */
 ?>
 

--- a/patterns/template-index-writer.php
+++ b/patterns/template-index-writer.php
@@ -4,7 +4,7 @@
  * Slug: twentytwentyfour/template-index-writer
  * Template Types: index, home
  * Viewport width: 1400
- * Inserter: no
+ * Inserter: false
  */
 ?>
 

--- a/patterns/template-search-portfolio.php
+++ b/patterns/template-search-portfolio.php
@@ -4,7 +4,7 @@
  * Slug: twentytwentyfour/template-search-portfolio
  * Template Types: search
  * Viewport width: 1400
- * Inserter: no
+ * Inserter: false
  */
 ?>
 

--- a/patterns/template-search-writer.php
+++ b/patterns/template-search-writer.php
@@ -4,7 +4,7 @@
  * Slug: twentytwentyfour/template-search-writer
  * Template Types: search
  * Viewport width: 1400
- * Inserter: no
+ * Inserter: false
  */
 ?>
 

--- a/patterns/template-single-portfolio.php
+++ b/patterns/template-single-portfolio.php
@@ -4,7 +4,7 @@
  * Slug: twentytwentyfour/template-single-portfolio
  * Template Types: posts, single
  * Viewport width: 1400
- * Inserter: no
+ * Inserter: false
  */
 ?>
 


### PR DESCRIPTION
**Description**
Fixes  #578.

<!-- Describe the purpose or reason for the pull request -->
The official documentation says that `false` should be used instead of `no` for the `inserter` property.

> inserter (optional): By default, all patterns will appear in the inserter. To hide a pattern so that it can only be inserted programmatically, set the inserter to false.
source (optional): A string that denotes the source of the pattern. 

https://developer.wordpress.org/block-editor/reference-guides/block-api/block-patterns/

**Testing Instructions**
Check that hidden patterns are not available from the inserter.

**Contributors**
benoitchantre

<!-- Please ensure anyone who contributed on linked issues and within this pull request have _AT LEAST_ their GitHub Username listed in the `CONTRIBUTORS.md` file as part of this PR. -->
