### PR TITLE
Place post navigation in a <nav> and update the link label

### DIFF
--- a/patterns/hidden-post-navigation.php
+++ b/patterns/hidden-post-navigation.php
@@ -8,7 +8,7 @@
 
 <!-- wp:group {"tagName":"nav","ariaLabel":"<?php esc_attr_e( 'Posts', 'twentytwentyfour') ?>","style":{"spacing":{"padding":{"bottom":"0vh"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 <nav class="wp-block-group" style="padding-bottom:0vh" aria-label="<?php esc_attr_e( 'Posts', 'twentytwentyfour') ?>">
-<!-- wp:post-navigation-link {"type":"previous","label":"<?php echo esc_html_x( 'Previous: ', 'Label before the title of the previous post. There is a space after the colon.', 'twentytwentyfour' )?>","showTitle":true,"linkLabel":true,"arrow":"arrow"} /-->
-<!-- wp:post-navigation-link {"label":"<?php echo esc_html_x( 'Next: ', 'Label before the title of the next post. There is a space after the colon.', 'twentytwentyfour' )?>","showTitle":true,"linkLabel":true,"arrow":"arrow"} /-->
+<!-- wp:post-navigation-link {"type":"previous","label":"<?php echo esc_html_x( 'Previous: ', 'Label before the title of the previous post. There is a space after the colon.', 'twentytwentyfour' ); ?>","showTitle":true,"linkLabel":true,"arrow":"arrow"} /-->
+<!-- wp:post-navigation-link {"label":"<?php echo esc_html_x( 'Next: ', 'Label before the title of the next post. There is a space after the colon.', 'twentytwentyfour' ); ?>","showTitle":true,"linkLabel":true,"arrow":"arrow"} /-->
 </nav>
 <!-- /wp:group -->

--- a/patterns/hidden-post-navigation.php
+++ b/patterns/hidden-post-navigation.php
@@ -6,8 +6,8 @@
  */
 ?>
 
-<!-- wp:group {"tagName":"nav","ariaLabel":"<?php esc_attr_e( 'Posts', 'twentytwentyfour') ?>","style":{"spacing":{"padding":{"bottom":"0vh"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<nav class="wp-block-group" style="padding-bottom:0vh" aria-label="<?php esc_attr_e( 'Posts', 'twentytwentyfour') ?>">
+<!-- wp:group {"tagName":"nav","ariaLabel":"<?php esc_attr_e( 'Posts', 'twentytwentyfour' ); ?>","style":{"spacing":{"padding":{"bottom":"0vh"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<nav class="wp-block-group" style="padding-bottom:0vh" aria-label="<?php esc_attr_e( 'Posts', 'twentytwentyfour' ); ?>">
 <!-- wp:post-navigation-link {"type":"previous","label":"<?php echo esc_html_x( 'Previous: ', 'Label before the title of the previous post. There is a space after the colon.', 'twentytwentyfour' ); ?>","showTitle":true,"linkLabel":true,"arrow":"arrow"} /-->
 <!-- wp:post-navigation-link {"label":"<?php echo esc_html_x( 'Next: ', 'Label before the title of the next post. There is a space after the colon.', 'twentytwentyfour' ); ?>","showTitle":true,"linkLabel":true,"arrow":"arrow"} /-->
 </nav>

--- a/patterns/hidden-post-navigation.php
+++ b/patterns/hidden-post-navigation.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Title: Post navigation
+ * slug: twentytwentyfour/post-navigation
+ * inserter: no
+ */
+?>
+
+<!-- wp:group {"tagName":"nav","ariaLabel":"<?php esc_attr_e( 'Posts', 'twentytwentyfour') ?>","style":{"spacing":{"padding":{"bottom":"0vh"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<nav class="wp-block-group" style="padding-bottom:0vh" aria-label="<?php esc_attr_e( 'Posts', 'twentytwentyfour') ?>">
+<!-- wp:post-navigation-link {"type":"previous","label":"<?php echo esc_html_x( 'Previous: ', 'Label before the title of the previous post. There is a space after the colon.', 'twentytwentyfour' )?>","showTitle":true,"linkLabel":true,"arrow":"arrow"} /-->
+<!-- wp:post-navigation-link {"label":"<?php echo esc_html_x( 'Next: ', 'Label before the title of the next post. There is a space after the colon.', 'twentytwentyfour' )?>","showTitle":true,"linkLabel":true,"arrow":"arrow"} /-->
+</nav>
+<!-- /wp:group -->

--- a/templates/single-with-sidebar.html
+++ b/templates/single-with-sidebar.html
@@ -37,11 +37,9 @@
 <div style="height:4rem" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"0vh"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group" style="padding-bottom:0vh"><!-- wp:post-navigation-link {"type":"previous","arrow":"arrow"} /-->
+<!-- wp:pattern {"slug":"twentytwentyfour/post-navigation"} /-->
 
-<!-- wp:post-navigation-link {"label":"Next","arrow":"arrow"} /--></div>
-<!-- /wp:group --></div>
+</div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->
 

--- a/templates/single.html
+++ b/templates/single.html
@@ -40,11 +40,9 @@
 <div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"0vh"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group" style="padding-bottom:0vh">
-	<!-- wp:post-navigation-link {"type":"previous","arrow":"arrow"} /-->
-	<!-- wp:post-navigation-link {"label":"Next","arrow":"arrow"} /--></div>
-<!-- /wp:group --></div>
+<!-- wp:pattern {"slug":"twentytwentyfour/post-navigation"} /-->
+
+</div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></main>
 <!-- /wp:group -->


### PR DESCRIPTION
**Description**
<!-- Describe the purpose or reason for the pull request -->
Partial for https://github.com/WordPress/twentytwentyfour/issues/537

Updates the post navigation link (next and previous post):
- Moves the markup to a pattern
- Changes the wrapping div to a nav
- Includes the post title as part of the link text

**Screenshots**
<img width="661" alt="Updated next and previous post labels 2023-10-09" src="https://github.com/WordPress/twentytwentyfour/assets/7422055/8722d39f-8106-4120-84b9-c32d4fc5af1b">

**Testing Instructions**
Make sure your WordPress installation has enough content so that you can navigate to both the next and previous posts.
Confirm that both the "next" and "previous" labels as well as the post title title and arrow shows.

- View a single post on the front and the template in the Site Editor
- View a **single post with a sidebar** on the front and the template in the Site Editor 

