### PR TITLE
Tweak spacing presets on mobile

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -162,7 +162,7 @@
 			"spacingSizes": [
 				{
 					"name": "1",
-					"size": "min(1rem, 1vw)",
+					"size": "1rem",
 					"slug": "10"
 				},
 				{


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Fixes the issue commented [here](https://github.com/WordPress/twentytwentyfour/pull/557#issuecomment-1746394168).

This PR makes the preset 10 to always be 1rem. This should keep the desktop version looking the same but improve the mobile version. A lot of patterns and templates use this preset and I generally found that this was an improvement to what we had before.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

Before | After 
--- | ---
<img width="344" alt="Screenshot 2023-10-09 at 18 25 27" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/69628aed-9922-455b-aea4-f4c095cae5cb"> | <img width="342" alt="Screenshot 2023-10-09 at 18 26 54" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/d4cdec62-6436-427c-960a-230ed784f206">


Before | After 
--- | ---
<img width="337" alt="Screenshot 2023-10-09 at 18 45 52" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/e5b6b476-ed7c-457e-8140-acd59e3c13b9"> | <img width="344" alt="Screenshot 2023-10-09 at 18 31 48" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/17b75507-77e8-46e3-b7a0-2cd7f4cde8ff">


Before | After 
--- | ---
<img width="338" alt="Screenshot 2023-10-09 at 18 45 40" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/536ca1de-af23-499a-a631-86c8f9c5b16c"> | <img width="348" alt="Screenshot 2023-10-09 at 18 34 24" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/4f8d13a9-9736-47c5-8a2e-648c3fb527c9">

