### PR TITLE
add an Old Style font stack

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -236,6 +236,11 @@
 					"fontFamily": "Cardo",
 					"name": "Cardo",
 					"slug": "heading"
+				},
+				{
+					"fontFamily": "'Iowan Old Style', 'Palatino Linotype', 'URW Palladio L', P052, serif",
+					"name": "Old Style",
+					"slug": "old-style"
 				}
 			],
 			"fontSizes": [


### PR DESCRIPTION
Add an Old Style (serif) font stack (based on modernfontstacks.com) as a light-weight alternative for Cardo

Example implementation of #572
