### PR TITLE
add a Neo-Grotesque font stack

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -236,6 +236,11 @@
 					"fontFamily": "Cardo",
 					"name": "Cardo",
 					"slug": "heading"
+				},
+				{
+					"fontFamily": "Inter, Roboto, 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', Arial, sans-serif",
+					"name": "Neo-Grotesque",
+					"slug": "neo-grotesque"
 				}
 			],
 			"fontSizes": [


### PR DESCRIPTION
Add a Neo-Grotesque (sans-serif) font stack (based on modernfontstacks.com) as a light-weight alternative for Inter

Example implementation of #572
