### PR TITLE
Re-add area and tagName attributes to header template part calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ turns into
 
 and 
 
-`<!-- wp:template-part {"slug":"header-portfolio","theme":"twentytwentyfour","area":"header"} /-->`
+`<!-- wp:template-part {"slug":"header-portfolio","theme":"twentytwentyfour","area":"header","tagName":"header"} /-->`
 
 turns into 
 
-`<!-- wp:template-part {"slug":"header-portfolio","area":"header"} /-->`
+`<!-- wp:template-part {"slug":"header-portfolio","area":"header","tagName":"header"} /-->`
 
 If we are constantly assigning properties to the same block over and over again (ie: border radius to images), consider moving those properties to the theme.json. 
 

--- a/patterns/template-archive-portfolio.php
+++ b/patterns/template-archive-portfolio.php
@@ -8,7 +8,7 @@
  */
 ?>
 
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignfull">

--- a/patterns/template-archive-writer.php
+++ b/patterns/template-archive-writer.php
@@ -8,7 +8,7 @@
  */
 ?>
 
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0","margin":{"top":"0"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group" style="margin-top:0">

--- a/patterns/template-home-business.php
+++ b/patterns/template-home-business.php
@@ -8,7 +8,7 @@
  */
 ?>
 
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0","margin":{"top":"0"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group" style="margin-top:0">

--- a/patterns/template-home-portfolio.php
+++ b/patterns/template-home-portfolio.php
@@ -8,7 +8,7 @@
  */
 ?>
 
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"},"tagName":"main"} -->
 <main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">

--- a/patterns/template-home-writer.php
+++ b/patterns/template-home-writer.php
@@ -8,7 +8,7 @@
  */
 ?>
 
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"},"tagName":"main"} -->
 <main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">

--- a/patterns/template-index-portfolio.php
+++ b/patterns/template-index-portfolio.php
@@ -7,7 +7,7 @@
  */
 ?>
 
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignfull">

--- a/patterns/template-index-writer.php
+++ b/patterns/template-index-writer.php
@@ -8,7 +8,7 @@
  */
 ?>
 
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0","margin":{"top":"0"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group" style="margin-top:0">

--- a/patterns/template-search-portfolio.php
+++ b/patterns/template-search-portfolio.php
@@ -8,7 +8,7 @@
  */
 ?>
 
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignfull">

--- a/patterns/template-search-writer.php
+++ b/patterns/template-search-writer.php
@@ -8,7 +8,7 @@
  */
 ?>
 
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0","margin":{"top":"0"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group" style="margin-top:0">

--- a/patterns/template-single-portfolio.php
+++ b/patterns/template-single-portfolio.php
@@ -8,7 +8,7 @@
  */
 ?>
 
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignfull"><!-- wp:spacer {"height":"var:preset|spacing|40"} -->

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|30"}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--50)">

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignfull">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignfull">

--- a/templates/page-no-title.html
+++ b/templates/page-no-title.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0"}}}} -->
 <main class="wp-block-group" style="margin-top:0">

--- a/templates/page-wide.html
+++ b/templates/page-wide.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","layout":{"type":"default"}} -->
 <main class="wp-block-group"><!-- wp:group {"style":{"spacing":{"padding":{"top":"0vh","bottom":"6vh"}}},"layout":{"type":"constrained"}} -->

--- a/templates/page-with-sidebar.html
+++ b/templates/page-with-sidebar.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group"><!-- wp:group {"layout":{"type":"constrained"}} -->

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignfull">

--- a/templates/single-with-sidebar.html
+++ b/templates/single-with-sidebar.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0vh","bottom":"0vh"},"padding":{"top":"10vh","bottom":"8vh"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:0vh;margin-bottom:0vh;padding-top:10vh;padding-bottom:8vh"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"1rem","left":"1rem"}}}} -->

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","align":"full"} -->
 <main class="wp-block-group alignfull"><!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50"},"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->


### PR DESCRIPTION
`area` and `tagName` attributes are added again to the header template part calls in all templates and patterns. Fixes #600.