### PR TITLE
Rename footer template parts and patterns

### DIFF
--- a/parts/footer-portfolio.html
+++ b/parts/footer-portfolio.html
@@ -1,1 +1,0 @@
-<!-- wp:pattern {"slug":"twentytwentyfour/footer-portfolio"} /-->

--- a/parts/footer-writer.html
+++ b/parts/footer-writer.html
@@ -1,1 +1,0 @@
-<!-- wp:pattern {"slug":"twentytwentyfour/footer-writer"} /-->

--- a/patterns/footer-portfolio.php
+++ b/patterns/footer-portfolio.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Footer portfolio
+ * Title: Two column footer with colophon
  * Slug: twentytwentyfour/footer-portfolio
  * Categories: footer
  * Block Types: core/template-part/footer

--- a/patterns/footer-writer.php
+++ b/patterns/footer-writer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Footer writer
+ * Title: Minimal centered footer with logo and navigation
  * Slug: twentytwentyfour/footer-writer
  * Categories: footer
  * Block Types: core/template-part/footer

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Default footer
+ * Title: Three column footer with colophon
  * Slug: twentytwentyfour/footer
  * Categories: footer
  * Block Types: core/template-part/footer

--- a/theme.json
+++ b/theme.json
@@ -922,17 +922,7 @@
 		{
 			"area": "footer",
 			"name": "footer",
-			"title": "Three column footer with colophon"
-		},
-		{
-			"area": "footer",
-			"name": "footer-portfolio",
-			"title": "Two column footer with colophon"
-		},
-		{
-			"area": "footer",
-			"name": "footer-writer",
-			"title": "Minimal centered footer with logo and navigation"
+			"title": "Footer"
 		},
 		{
 			"area": "uncategorized",

--- a/theme.json
+++ b/theme.json
@@ -922,17 +922,17 @@
 		{
 			"area": "footer",
 			"name": "footer",
-			"title": "Footer"
+			"title": "Three column footer with colophon"
 		},
 		{
 			"area": "footer",
 			"name": "footer-portfolio",
-			"title": "Footer: Portfolio"
+			"title": "Two column footer with colophon"
 		},
 		{
 			"area": "footer",
 			"name": "footer-writer",
-			"title": "Footer: Writer"
+			"title": "Minimal centered footer with logo and navigation"
 		},
 		{
 			"area": "uncategorized",


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->
Closes https://github.com/WordPress/twentytwentyfour/issues/411

This renames the patterns to be descriptive in the UI:

<img width="1235" alt="Screenshot 2023-10-10 at 17 58 48" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/45d88a90-a6ed-496b-a54a-4760fd3b5997">
