### PR TITLE
Updated styles for plain quote"

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -660,7 +660,7 @@
 				"color": {
 					"background": "var(--wp--preset--color--base-2)"
 				},
-				"css": "& :where(p) {margin-block-start:0;margin-block-end:calc(var(--wp--preset--spacing--10) + 0.5rem);} &.has-text-align-right.is-style-plain, .rtl .is-style-plain.wp-block-quote:not(.has-text-align-center):not(.has-text-align-left){border-width: 0 2px 0 0;padding-left: 0;padding-right:calc(var(--wp--preset--spacing--20) + 0.5rem);} &.has-text-align-left.is-style-plain, body:not(.rtl) .is-style-plain.wp-block-quote:not(.has-text-align-center):not(.has-text-align-left){border-width: 0 0 0 2px;padding-right: 0;padding-left:calc(var(--wp--preset--spacing--20) + 0.5rem);}",
+				"css": "& :where(p) {margin-block-start:0;margin-block-end:calc(var(--wp--preset--spacing--10) + 0.5rem);} &.has-text-align-right.is-style-plain, .rtl .is-style-plain.wp-block-quote:not(.has-text-align-center):not(.has-text-align-left){border-width: 0 2px 0 0;padding-left: 0;padding-right:calc(var(--wp--preset--spacing--20) + 0.5rem);} &.has-text-align-left.is-style-plain, body:not(.rtl) .is-style-plain.wp-block-quote:not(.has-text-align-center):not(.has-text-align-right){border-width: 0 0 0 2px;padding-right: 0;padding-left:calc(var(--wp--preset--spacing--20) + 0.5rem);}",
 				"elements": {
 					"cite": {
 						"typography": {

--- a/theme.json
+++ b/theme.json
@@ -660,7 +660,7 @@
 				"color": {
 					"background": "var(--wp--preset--color--base-2)"
 				},
-				"css": "& :where(p) {margin-block-start:0;margin-block-end:calc(var(--wp--preset--spacing--10) + 0.5rem);}",
+				"css": "& :where(p) {margin-block-start:0;margin-block-end:calc(var(--wp--preset--spacing--10) + 0.5rem);} &.has-text-align-right.is-style-plain, .rtl .is-style-plain.wp-block-quote:not(.has-text-align-center):not(.has-text-align-left){border-width: 0 2px 0 0;padding-left: 0;padding-right:calc(var(--wp--preset--spacing--20) + 0.5rem);} &.has-text-align-left.is-style-plain, body:not(.rtl) .is-style-plain.wp-block-quote:not(.has-text-align-center):not(.has-text-align-left){border-width: 0 0 0 2px;padding-right: 0;padding-left:calc(var(--wp--preset--spacing--20) + 0.5rem);}",
 				"elements": {
 					"cite": {
 						"typography": {
@@ -690,7 +690,7 @@
 							"color": "var(--wp--preset--color--contrast)",
 							"radius": "0",
 							"style": "solid",
-							"width": "0 0 0 2px"
+							"width": "0"
 						},
 						"color": {
 							"background": "transparent"
@@ -698,13 +698,16 @@
 						"spacing": {
 							"padding": {
 								"bottom": "var(--wp--preset--spacing--20)",
-								"left": "calc(var(--wp--preset--spacing--20) + 0.5rem)",
-								"right": "0",
+								"left": "var(--wp--preset--spacing--20)",
+								"right": "var(--wp--preset--spacing--20)",
 								"top": "var(--wp--preset--spacing--20)"
 							}
 						},
 						"typography": {
-							"fontSize": "var(--wp--preset--font-size--medium)"
+							"fontFamily": "var(--wp--preset--font-family--body)",
+							"fontStyle": "normal",
+							"fontSize": "var(--wp--preset--font-size--medium)",
+							"lineHeight": "1.5"
 						}
 					}
 				}


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Closes https://github.com/WordPress/twentytwentyfour/issues/439

I tried to maintain the CSS to a minimum and not break RTL

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

RTL | LTR
--- | ---
 <img width="753" alt="Screenshot 2023-10-11 at 11 28 50" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/88e3c99e-d478-4df5-a7a7-565799450629"> | <img width="742" alt="Screenshot 2023-10-11 at 11 30 22" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/2614dcb9-661f-4c49-8d0a-a657be136bdb">
