### PR TITLE
Fix global heading sizes

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -867,7 +867,7 @@
 			},
 			"h4": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)"
+					"fontSize": "clamp(1.1rem, 1.1rem + ((1vw - 0.2rem) * 0.767), 1.5rem)"
 				}
 			},
 			"h5": {
@@ -877,7 +877,7 @@
 			},
 			"h6": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"heading": {


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Closes https://github.com/WordPress/twentytwentyfour/issues/551

This PR adds replicates the flexible font size for the h4 heading so it scales like the rest of the headings.

H4 and H5 are used on two patterns but both of them use a preset font size instead of the global value, so they are unaffected by this change. H6 is never used on templates or patterns.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

**Desktop**

<img width="909" alt="Screenshot 2023-10-11 at 13 20 40" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/881ce1bc-111d-4304-94b0-71754f55c784">


**Mobile**


<img width="412" alt="Screenshot 2023-10-11 at 13 20 17" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/543d869c-8591-426b-89ae-16391dcb50fc">
