### PR TITLE
Fix spacing issues with translation strings

### DIFF
--- a/patterns/centered-statement.php
+++ b/patterns/centered-statement.php
@@ -17,9 +17,9 @@
 		<!-- /wp:spacer -->
 
 		<!-- wp:paragraph {"align":"center","style":{"typography":{"lineHeight":"1.2","fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-large","fontFamily":"heading"} -->
-		<p class="has-text-align-center has-heading-font-family has-x-large-font-size" style="font-style:normal;font-weight:400;line-height:1.2">
-			<?php echo wp_kses_post( __( '<em>Études</em> is not confined to the past—we are passionate about the cutting edge designs shaping our world today.', 'twentytwentyfour' ) ); ?>
-		</p>
+		<p class="has-text-align-center has-heading-font-family has-x-large-font-size" style="font-style:normal;font-weight:400;line-height:1.2"><?php 
+			echo wp_kses_post( __( '<em>Études</em> is not confined to the past—we are passionate about the cutting edge designs shaping our world today.', 'twentytwentyfour' ) );
+		?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:spacer {"height":"var:preset|spacing|50"} -->

--- a/patterns/centered-statement.php
+++ b/patterns/centered-statement.php
@@ -17,9 +17,7 @@
 		<!-- /wp:spacer -->
 
 		<!-- wp:paragraph {"align":"center","style":{"typography":{"lineHeight":"1.2","fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-large","fontFamily":"heading"} -->
-		<p class="has-text-align-center has-heading-font-family has-x-large-font-size" style="font-style:normal;font-weight:400;line-height:1.2"><?php 
-			echo wp_kses_post( __( '<em>Études</em> is not confined to the past—we are passionate about the cutting edge designs shaping our world today.', 'twentytwentyfour' ) );
-		?></p>
+		<p class="has-text-align-center has-heading-font-family has-x-large-font-size" style="font-style:normal;font-weight:400;line-height:1.2"><?php echo wp_kses_post( __( '<em>Études</em> is not confined to the past—we are passionate about the cutting edge designs shaping our world today.', 'twentytwentyfour' ) ); ?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:spacer {"height":"var:preset|spacing|50"} -->

--- a/patterns/clients.php
+++ b/patterns/clients.php
@@ -13,9 +13,7 @@
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}},"border":{"radius":"16px"}},"backgroundColor":"base-2","layout":{"type":"default"}} -->
 	<div class="wp-block-group alignwide has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
 		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center"><?php
-			echo esc_html_x( 'We’ve worked with some of the best companies.', 'Sample content above the list of companies.', 'twentytwentyfour' );
-		?></p>
+		<p class="has-text-align-center"><?php echo esc_html_x( 'We’ve worked with some of the best companies.', 'Sample content above the list of companies.', 'twentytwentyfour' ); ?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:spacer {"height":"var:preset|spacing|10"} -->

--- a/patterns/clients.php
+++ b/patterns/clients.php
@@ -13,9 +13,9 @@
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}},"border":{"radius":"16px"}},"backgroundColor":"base-2","layout":{"type":"default"}} -->
 	<div class="wp-block-group alignwide has-base-2-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
 		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center">
-			<?php echo esc_html_x( 'We’ve worked with some of the best companies.', 'Sample content above the list of companies.', 'twentytwentyfour' ); ?>
-		</p>
+		<p class="has-text-align-center"><?php
+			echo esc_html_x( 'We’ve worked with some of the best companies.', 'Sample content above the list of companies.', 'twentytwentyfour' );
+		?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:spacer {"height":"var:preset|spacing|10"} -->

--- a/patterns/columns.php
+++ b/patterns/columns.php
@@ -14,9 +14,7 @@
 		<!-- wp:column {"width":"33%"} -->
 		<div class="wp-block-column" style="flex-basis:33%">
 			<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"large","fontFamily":"heading"} -->
-			<p class="has-heading-font-family has-large-font-size" style="line-height:1.2"><?php
-				echo esc_html_x( 'We recognize the role architecture plays in shaping a sustainable future.', 'Heading of the Columns', 'twentytwentyfour' );
-			?></p>
+			<p class="has-heading-font-family has-large-font-size" style="line-height:1.2"><?php echo esc_html_x( 'We recognize the role architecture plays in shaping a sustainable future.', 'Heading of the Columns', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -28,15 +26,11 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"left","flexWrap":"nowrap"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"500"}}} -->
-					<p style="font-style:normal;font-weight:500"><?php
-						esc_html_e( 'Consulting', 'twentytwentyfour' );
-					?></p>
+					<p style="font-style:normal;font-weight:500"><?php esc_html_e( 'Consulting', 'twentytwentyfour' ); ?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:paragraph -->
-					<p><?php
-						echo esc_html_x( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'Vision Content for Columns', 'twentytwentyfour' );
-					?></p>
+					<p><?php echo esc_html_x( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'Vision Content for Columns', 'twentytwentyfour' ); ?></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:group -->
@@ -44,15 +38,11 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"500"}}} -->
-					<p style="font-style:normal;font-weight:500">
-						<?php esc_html_e( 'Project Management', 'twentytwentyfour' ); ?>
-					</p>
+					<p style="font-style:normal;font-weight:500"><?php esc_html_e( 'Project Management', 'twentytwentyfour' ); ?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:paragraph -->
-					<p>
-						<?php echo esc_html_x( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'Vision Content for Columns', 'twentytwentyfour' ); ?>
-					</p>
+					<p><?php echo esc_html_x( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'Vision Content for Columns', 'twentytwentyfour' ); ?></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:group -->
@@ -64,15 +54,11 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"500"}}} -->
-					<p style="font-style:normal;font-weight:500"><?php
-						esc_html_e( 'Design', 'twentytwentyfour' );
-					?></p>
+					<p style="font-style:normal;font-weight:500"><?php esc_html_e( 'Design', 'twentytwentyfour' ); ?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:paragraph -->
-					<p><?php 
-						echo esc_html_x( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'Vision Content for Columns', 'twentytwentyfour' );
-					?></p>
+					<p><?php echo esc_html_x( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'Vision Content for Columns', 'twentytwentyfour' ); ?></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:group -->
@@ -80,15 +66,11 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"500"}}} -->
-					<p style="font-style:normal;font-weight:500"><?php
-						esc_html_e( 'Maintenance', 'twentytwentyfour' );
-					?></p>
+					<p style="font-style:normal;font-weight:500"><?php esc_html_e( 'Maintenance', 'twentytwentyfour' ); ?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:paragraph -->
-					<p><?php
-						echo esc_html_x( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'Vision Content for Columns', 'twentytwentyfour' );
-					?></p>
+					<p><?php echo esc_html_x( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'Vision Content for Columns', 'twentytwentyfour' ); ?></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:group -->

--- a/patterns/columns.php
+++ b/patterns/columns.php
@@ -14,9 +14,9 @@
 		<!-- wp:column {"width":"33%"} -->
 		<div class="wp-block-column" style="flex-basis:33%">
 			<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"large","fontFamily":"heading"} -->
-			<p class="has-heading-font-family has-large-font-size" style="line-height:1.2">
-				<?php echo esc_html_x( 'We recognize the role architecture plays in shaping a sustainable future.', 'Heading of the Columns', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-heading-font-family has-large-font-size" style="line-height:1.2"><?php
+				echo esc_html_x( 'We recognize the role architecture plays in shaping a sustainable future.', 'Heading of the Columns', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -28,15 +28,15 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"left","flexWrap":"nowrap"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"500"}}} -->
-					<p style="font-style:normal;font-weight:500">
-						<?php esc_html_e( 'Consulting', 'twentytwentyfour' ); ?>
-					</p>
+					<p style="font-style:normal;font-weight:500"><?php
+						esc_html_e( 'Consulting', 'twentytwentyfour' );
+					?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:paragraph -->
-					<p>
-						<?php echo esc_html_x( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'Vision Content for Columns', 'twentytwentyfour' ); ?>
-					</p>
+					<p><?php
+						echo esc_html_x( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'Vision Content for Columns', 'twentytwentyfour' );
+					?></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:group -->
@@ -64,15 +64,15 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"500"}}} -->
-					<p style="font-style:normal;font-weight:500">
-						<?php esc_html_e( 'Design', 'twentytwentyfour' ); ?>
-					</p>
+					<p style="font-style:normal;font-weight:500"><?php
+						esc_html_e( 'Design', 'twentytwentyfour' );
+					?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:paragraph -->
-					<p>
-						<?php echo esc_html_x( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'Vision Content for Columns', 'twentytwentyfour' ); ?>
-					</p>
+					<p><?php 
+						echo esc_html_x( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'Vision Content for Columns', 'twentytwentyfour' );
+					?></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:group -->
@@ -80,15 +80,15 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"500"}}} -->
-					<p style="font-style:normal;font-weight:500">
-						<?php esc_html_e( 'Maintenance', 'twentytwentyfour' ); ?>
-					</p>
+					<p style="font-style:normal;font-weight:500"><?php
+						esc_html_e( 'Maintenance', 'twentytwentyfour' );
+					?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:paragraph -->
-					<p>
-						<?php echo esc_html_x( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'Vision Content for Columns', 'twentytwentyfour' ); ?>
-					</p>
+					<p><?php
+						echo esc_html_x( 'Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces.', 'Vision Content for Columns', 'twentytwentyfour' );
+					?></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:group -->

--- a/patterns/faq.php
+++ b/patterns/faq.php
@@ -11,9 +11,7 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"backgroundColor":"contrast","textColor":"base","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-base-color has-contrast-background-color has-text-color has-background has-link-color" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
 	<!-- wp:heading {"align":"wide","style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}},"typography":{"fontSize":"10rem","letterSpacing":"-0.02em"}},"textColor":"base"} -->
-	<h2 class="wp-block-heading alignwide has-base-color has-text-color has-link-color" style="font-size:10rem;letter-spacing:-0.02em"><?php
-		echo esc_html_x( 'FAQs', 'Heading of the FAQs', 'twentytwentyfour' );
-	?></h2>
+	<h2 class="wp-block-heading alignwide has-base-color has-text-color has-link-color" style="font-size:10rem;letter-spacing:-0.02em"><?php echo esc_html_x( 'FAQs', 'Heading of the FAQs', 'twentytwentyfour' ); ?></h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->

--- a/patterns/faq.php
+++ b/patterns/faq.php
@@ -11,9 +11,9 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"backgroundColor":"contrast","textColor":"base","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-base-color has-contrast-background-color has-text-color has-background has-link-color" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
 	<!-- wp:heading {"align":"wide","style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}},"typography":{"fontSize":"10rem","letterSpacing":"-0.02em"}},"textColor":"base"} -->
-	<h2 class="wp-block-heading alignwide has-base-color has-text-color has-link-color" style="font-size:10rem;letter-spacing:-0.02em">
-		<?php echo esc_html_x( 'FAQs', 'Heading of the FAQs', 'twentytwentyfour' ); ?>
-	</h2>
+	<h2 class="wp-block-heading alignwide has-base-color has-text-color has-link-color" style="font-size:10rem;letter-spacing:-0.02em"><?php
+		echo esc_html_x( 'FAQs', 'Heading of the FAQs', 'twentytwentyfour' );
+	?></h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
@@ -24,52 +24,36 @@
 
 		<!-- wp:details {"style":{"spacing":{"margin":{"top":"0"}}},"className":"is-style-arrow-icon-details","fontSize":"medium"} -->
 		<details class="wp-block-details is-style-arrow-icon-details has-medium-font-size" style="margin-top:0">
-			<summary>
-				<?php echo esc_html_x( 'What is your process working in smaller projects?', 'Question on the details block', 'twentytwentyfour' ); ?>
-			</summary>
+			<summary><?php echo esc_html_x( 'What is your process working in smaller projects?', 'Question on the details block', 'twentytwentyfour' ); ?></summary>
 			<!-- wp:paragraph {"placeholder":"Type / to add a hidden block","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-3"}}}},"textColor":"contrast-3"} -->
-			<p class="has-contrast-3-color has-text-color has-link-color">
-				<?php echo esc_html_x( 'Études offers comprehensive consulting, management, design, and research solutions. Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces. Every architectural endeavor is an opportunity to shape the future.', 'Hidden answer on the details block', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-contrast-3-color has-text-color has-link-color"><?php echo esc_html_x( 'Études offers comprehensive consulting, management, design, and research solutions. Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces. Every architectural endeavor is an opportunity to shape the future.', 'Hidden answer on the details block', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</details>
 		<!-- /wp:details -->
 
 		<!-- wp:details {"style":{"spacing":{"margin":{"top":"0"}}},"className":"is-style-arrow-icon-details","fontSize":"medium"} -->
 		<details class="wp-block-details is-style-arrow-icon-details has-medium-font-size" style="margin-top:0">
-			<summary>
-				<?php echo esc_html_x( 'Who is behind Études?', 'Question on the details block', 'twentytwentyfour' ); ?>
-			</summary>
+			<summary><?php echo esc_html_x( 'Who is behind Études?', 'Question on the details block', 'twentytwentyfour' ); ?></summary>
 			<!-- wp:paragraph {"placeholder":"Type / to add a hidden block","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-3"}}}},"textColor":"contrast-3"} -->
-			<p class="has-contrast-3-color has-text-color has-link-color">
-				<?php echo esc_html_x( 'Études offers comprehensive consulting, management, design, and research solutions. Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces. Every architectural endeavor is an opportunity to shape the future.', 'Hidden answer on the details block', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-contrast-3-color has-text-color has-link-color"><?php echo esc_html_x( 'Études offers comprehensive consulting, management, design, and research solutions. Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces. Every architectural endeavor is an opportunity to shape the future.', 'Hidden answer on the details block', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</details>
 		<!-- /wp:details -->
 
 		<!-- wp:details {"style":{"spacing":{"margin":{"top":"0"}}},"className":"is-style-arrow-icon-details","fontSize":"medium"} -->
 		<details class="wp-block-details is-style-arrow-icon-details has-medium-font-size" style="margin-top:0">
-			<summary>
-				<?php echo esc_html_x( 'I\'d like to get to meet fellow architects, how can I do that?', 'Question on the details block', 'twentytwentyfour' ); ?>
-			</summary>
+			<summary><?php echo esc_html_x( 'I\'d like to get to meet fellow architects, how can I do that?', 'Question on the details block', 'twentytwentyfour' ); ?></summary>
 			<!-- wp:paragraph {"placeholder":"Type / to add a hidden block","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-3"}}}},"textColor":"contrast-3"} -->
-			<p class="has-contrast-3-color has-text-color has-link-color">
-				<?php echo esc_html_x( 'Études offers comprehensive consulting, management, design, and research solutions. Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces. Every architectural endeavor is an opportunity to shape the future.', 'Hidden answer on the details block', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-contrast-3-color has-text-color has-link-color"><?php echo esc_html_x( 'Études offers comprehensive consulting, management, design, and research solutions. Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces. Every architectural endeavor is an opportunity to shape the future.', 'Hidden answer on the details block', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</details>
 		<!-- /wp:details -->
 
 		<!-- wp:details {"style":{"spacing":{"margin":{"top":"0"}}},"className":"is-style-arrow-icon-details","fontSize":"medium"} -->
 		<details class="wp-block-details is-style-arrow-icon-details has-medium-font-size" style="margin-top:0">
-			<summary>
-				<?php echo esc_html_x( 'Can I apply to be a part of the team or work as a contractor?', 'Question on the details block', 'twentytwentyfour' ); ?>
-			</summary>
+			<summary><?php echo esc_html_x( 'Can I apply to be a part of the team or work as a contractor?', 'Question on the details block', 'twentytwentyfour' ); ?></summary>
 			<!-- wp:paragraph {"placeholder":"Type / to add a hidden block","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-3"}}}},"textColor":"contrast-3"} -->
-			<p class="has-contrast-3-color has-text-color has-link-color">
-				<?php echo esc_html_x( 'Études offers comprehensive consulting, management, design, and research solutions. Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces. Every architectural endeavor is an opportunity to shape the future.', 'Hidden answer on the details block', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-contrast-3-color has-text-color has-link-color"><?php echo esc_html_x( 'Études offers comprehensive consulting, management, design, and research solutions. Our vision is to be at the forefront of architectural innovation, fostering a global community of architects and enthusiasts united by a passion for creating spaces. Every architectural endeavor is an opportunity to shape the future.', 'Hidden answer on the details block', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</details>
 		<!-- /wp:details -->

--- a/patterns/feature-grid.php
+++ b/patterns/feature-grid.php
@@ -12,9 +12,7 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 	<div class="wp-block-group">
 		<!-- wp:heading {"textAlign":"center","className":"is-style-asterisk"} -->
-		<h2 class="wp-block-heading has-text-align-center is-style-asterisk"><?php
-			echo esc_html_x( 'A passion for creating spaces', 'Heading of the features', 'twentytwentyfour' );
-		?></h2>
+		<h2 class="wp-block-heading has-text-align-center is-style-asterisk"><?php echo esc_html_x( 'A passion for creating spaces', 'Heading of the features', 'twentytwentyfour' ); ?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
@@ -22,9 +20,7 @@
 		<!-- /wp:spacer -->
 
 		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center"><?php
-			echo esc_html_x( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.', 'Sub-heading of the features', 'twentytwentyfour' );
-		?></p>
+		<p class="has-text-align-center"><?php echo esc_html_x( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.', 'Sub-heading of the features', 'twentytwentyfour' ); ?></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->
@@ -39,15 +35,11 @@
 		<!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 		<div class="wp-block-column">
 			<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
-			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php
-				echo esc_html_x( 'Renovation and restoration', 'Sample feature heading', 'twentytwentyfour' );
-			?></h3>
+			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Renovation and restoration', 'Sample feature heading', 'twentytwentyfour' ); ?></h3>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"left"} -->
-			<p class="has-text-align-left"><?php
-				echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' );
-			?></p>
+			<p class="has-text-align-left"><?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -55,15 +47,11 @@
 		<!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 		<div class="wp-block-column">
 			<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
-			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php
-				echo esc_html_x( 'Continuous Support', 'Sample feature heading', 'twentytwentyfour' );
-			?></h3>
+			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Continuous Support', 'Sample feature heading', 'twentytwentyfour' ); ?></h3>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"left"} -->
-			<p class="has-text-align-left"><?php
-				echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' );
-			?></p>
+			<p class="has-text-align-left"><?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -71,15 +59,11 @@
 		<!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 		<div class="wp-block-column">
 			<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
-			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php
-				echo esc_html_x( 'App Access', 'Sample feature heading', 'twentytwentyfour' );
-			?></h3>
+			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'App Access', 'Sample feature heading', 'twentytwentyfour' ); ?></h3>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"left"} -->
-			<p class="has-text-align-left"><?php
-				echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' );
-			?></p>
+			<p class="has-text-align-left"><?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -96,15 +80,11 @@
 		<!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 		<div class="wp-block-column">
 			<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
-			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php
-				echo esc_html_x( 'Consulting', 'Sample feature heading', 'twentytwentyfour' );
-			?></h3>
+			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Consulting', 'Sample feature heading', 'twentytwentyfour' ); ?></h3>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"left"} -->
-			<p class="has-text-align-left"><?php
-				echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' );
-			?></p>
+			<p class="has-text-align-left"><?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -112,15 +92,11 @@
 		<!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 		<div class="wp-block-column">
 			<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
-			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php
-				echo esc_html_x( 'Project Management', 'Sample feature heading', 'twentytwentyfour' );
-			?></h3>
+			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Project Management', 'Sample feature heading', 'twentytwentyfour' ); ?></h3>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"left"} -->
-			<p class="has-text-align-left"><?php
-				echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' );
-			?></p>
+			<p class="has-text-align-left"><?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -128,15 +104,11 @@
 		<!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 		<div class="wp-block-column">
 			<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
-			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php
-				echo esc_html_x( 'Architectural Solutions', 'Sample feature heading', 'twentytwentyfour' );
-			?></h3>
+			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Architectural Solutions', 'Sample feature heading', 'twentytwentyfour' ); ?></h3>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"left"} -->
-			<p class="has-text-align-left"><?php
-				echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); 
-			?></p>
+			<p class="has-text-align-left"><?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->

--- a/patterns/feature-grid.php
+++ b/patterns/feature-grid.php
@@ -12,9 +12,9 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 	<div class="wp-block-group">
 		<!-- wp:heading {"textAlign":"center","className":"is-style-asterisk"} -->
-		<h2 class="wp-block-heading has-text-align-center is-style-asterisk">
-			<?php echo esc_html_x( 'A passion for creating spaces', 'Heading of the features', 'twentytwentyfour' ); ?>
-		</h2>
+		<h2 class="wp-block-heading has-text-align-center is-style-asterisk"><?php
+			echo esc_html_x( 'A passion for creating spaces', 'Heading of the features', 'twentytwentyfour' );
+		?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
@@ -22,9 +22,9 @@
 		<!-- /wp:spacer -->
 
 		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center">
-			<?php echo esc_html_x( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.', 'Sub-heading of the features', 'twentytwentyfour' ); ?>
-		</p>
+		<p class="has-text-align-center"><?php
+			echo esc_html_x( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.', 'Sub-heading of the features', 'twentytwentyfour' );
+		?></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->
@@ -39,15 +39,15 @@
 		<!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 		<div class="wp-block-column">
 			<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
-			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600">
-				<?php echo esc_html_x( 'Renovation and restoration', 'Sample feature heading', 'twentytwentyfour' ); ?>
-			</h3>
+			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php
+				echo esc_html_x( 'Renovation and restoration', 'Sample feature heading', 'twentytwentyfour' );
+			?></h3>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"left"} -->
-			<p class="has-text-align-left">
-				<?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-text-align-left"><?php
+				echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -55,15 +55,15 @@
 		<!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 		<div class="wp-block-column">
 			<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
-			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600">
-				<?php echo esc_html_x( 'Continuous Support', 'Sample feature heading', 'twentytwentyfour' ); ?>
-			</h3>
+			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php
+				echo esc_html_x( 'Continuous Support', 'Sample feature heading', 'twentytwentyfour' );
+			?></h3>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"left"} -->
-			<p class="has-text-align-left">
-				<?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-text-align-left"><?php
+				echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -71,15 +71,15 @@
 		<!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 		<div class="wp-block-column">
 			<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
-			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600">
-				<?php echo esc_html_x( 'App Access', 'Sample feature heading', 'twentytwentyfour' ); ?>
-			</h3>
+			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php
+				echo esc_html_x( 'App Access', 'Sample feature heading', 'twentytwentyfour' );
+			?></h3>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"left"} -->
-			<p class="has-text-align-left">
-				<?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-text-align-left"><?php
+				echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -96,15 +96,15 @@
 		<!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 		<div class="wp-block-column">
 			<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
-			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600">
-				<?php echo esc_html_x( 'Consulting', 'Sample feature heading', 'twentytwentyfour' ); ?>
-			</h3>
+			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php
+				echo esc_html_x( 'Consulting', 'Sample feature heading', 'twentytwentyfour' );
+			?></h3>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"left"} -->
-			<p class="has-text-align-left">
-				<?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-text-align-left"><?php
+				echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -112,15 +112,15 @@
 		<!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 		<div class="wp-block-column">
 			<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
-			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600">
-				<?php echo esc_html_x( 'Project Management', 'Sample feature heading', 'twentytwentyfour' ); ?>
-			</h3>
+			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php
+				echo esc_html_x( 'Project Management', 'Sample feature heading', 'twentytwentyfour' );
+			?></h3>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"left"} -->
-			<p class="has-text-align-left">
-				<?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-text-align-left"><?php
+				echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -128,15 +128,15 @@
 		<!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 		<div class="wp-block-column">
 			<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
-			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600">
-				<?php echo esc_html_x( 'Architectural Solutions', 'Sample feature heading', 'twentytwentyfour' ); ?>
-			</h3>
+			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php
+				echo esc_html_x( 'Architectural Solutions', 'Sample feature heading', 'twentytwentyfour' );
+			?></h3>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"left"} -->
-			<p class="has-text-align-left">
-				<?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-text-align-left"><?php
+				echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Architectural Solutions.', 'Sample feature content', 'twentytwentyfour' ); 
+			?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->

--- a/patterns/features-with-images.php
+++ b/patterns/features-with-images.php
@@ -15,15 +15,15 @@
 		<div class="wp-block-group">
 
 			<!-- wp:heading {"textAlign":"center","className":"is-style-asterisk"} -->
-			<h2 class="wp-block-heading has-text-align-center is-style-asterisk">
-				<?php echo esc_html_x( 'An array of resources', 'Sample content for heading of the section.', 'twentytwentyfour' ); ?>
-			</h2>
+			<h2 class="wp-block-heading has-text-align-center is-style-asterisk"><?php
+				echo esc_html_x( 'An array of resources', 'Sample content for heading of the section.', 'twentytwentyfour' );
+			?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
-			<p class="has-text-align-center">
-				<?php echo esc_html_x( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.', 'Sample content for the subheading for this pattern.', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-text-align-center"><?php
+				echo esc_html_x( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.', 'Sample content for the subheading for this pattern.', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->
@@ -37,30 +37,30 @@
 			<!-- wp:column {"verticalAlignment":"center","width":"40%"} -->
 			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:40%">
 				<!-- wp:heading {"level":3,"className":"is-style-asterisk"} -->
-				<h3 class="wp-block-heading is-style-asterisk">
-					<?php echo esc_html_x( 'Études Architect App', 'A heading for the list.', 'twentytwentyfour' ); ?>
-				</h3>
+				<h3 class="wp-block-heading is-style-asterisk"><?php
+					echo esc_html_x( 'Études Architect App', 'A heading for the list.', 'twentytwentyfour' );
+				?></h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:list {"style":{"typography":{"lineHeight":"1.75"}},"className":"is-style-checkmark-list"} -->
 				<ul class="is-style-checkmark-list" style="line-height:1.75">
 
 					<!-- wp:list-item -->
-					<li>
-						<?php echo esc_html_x( 'Collaborate with fellow architects.', 'A general list item.', 'twentytwentyfour' ); ?>
-					</li>
+					<li><?php
+						echo esc_html_x( 'Collaborate with fellow architects.', 'A general list item.', 'twentytwentyfour' );
+					?></li>
 					<!-- /wp:list-item -->
 
 					<!-- wp:list-item -->
-					<li>
-						<?php echo esc_html_x( 'Showcase your projects.', 'A general list item.', 'twentytwentyfour' ); ?>
-					</li>
+					<li><?php
+						echo esc_html_x( 'Showcase your projects.', 'A general list item.', 'twentytwentyfour' );
+					?></li>
 					<!-- /wp:list-item -->
 
 					<!-- wp:list-item -->
-					<li>
-						<?php echo esc_html_x( 'Experience the world of architecture.', 'A general list item.', 'twentytwentyfour' ); ?>
-					</li>
+					<li><?php
+						echo esc_html_x( 'Experience the world of architecture.', 'A general list item.', 'twentytwentyfour' );
+					?></li>
 					<!-- /wp:list-item -->
 
 				</ul>
@@ -99,29 +99,29 @@
 			<!-- wp:column {"verticalAlignment":"center","width":"40%"} -->
 			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:40%">
 				<!-- wp:heading {"level":3,"className":"is-style-asterisk"} -->
-				<h3 class="wp-block-heading is-style-asterisk">
-					<?php echo esc_html_x( 'Études Newsletter', 'A heading for the list.', 'twentytwentyfour' ); ?>
-				</h3>
+				<h3 class="wp-block-heading is-style-asterisk"><?php
+					echo esc_html_x( 'Études Newsletter', 'A heading for the list.', 'twentytwentyfour' );
+				?></h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:list {"style":{"typography":{"lineHeight":"1.75"}},"className":"is-style-checkmark-list"} -->
 				<ul class="is-style-checkmark-list" style="line-height:1.75">
 					<!-- wp:list-item -->
-					<li>
-						<?php echo esc_html_x( 'A world of thought-provoking articles.', 'A general list item.', 'twentytwentyfour' ); ?>
-					</li>
+					<li><?php
+						echo esc_html_x( 'A world of thought-provoking articles.', 'A general list item.', 'twentytwentyfour' );
+					?></li>
 					<!-- /wp:list-item -->
 
 					<!-- wp:list-item -->
-					<li>
-						<?php echo esc_html_x( 'Case studies that celebrate architecture.', 'A general list item.', 'twentytwentyfour' ); ?>
-					</li>
+					<li><?php
+						echo esc_html_x( 'Case studies that celebrate architecture.', 'A general list item.', 'twentytwentyfour' );
+					?></li>
 					<!-- /wp:list-item -->
 
 					<!-- wp:list-item -->
-					<li>
-						<?php echo esc_html_x( 'Exclusive access to design insights.', 'A general list item.', 'twentytwentyfour' ); ?>
-					</li>
+					<li><?php
+						echo esc_html_x( 'Exclusive access to design insights.', 'A general list item.', 'twentytwentyfour' );
+					?></li>
 					<!-- /wp:list-item -->
 				</ul>
 				<!-- /wp:list -->

--- a/patterns/features-with-images.php
+++ b/patterns/features-with-images.php
@@ -15,15 +15,11 @@
 		<div class="wp-block-group">
 
 			<!-- wp:heading {"textAlign":"center","className":"is-style-asterisk"} -->
-			<h2 class="wp-block-heading has-text-align-center is-style-asterisk"><?php
-				echo esc_html_x( 'An array of resources', 'Sample content for heading of the section.', 'twentytwentyfour' );
-			?></h2>
+			<h2 class="wp-block-heading has-text-align-center is-style-asterisk"><?php echo esc_html_x( 'An array of resources', 'Sample content for heading of the section.', 'twentytwentyfour' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"center","style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
-			<p class="has-text-align-center"><?php
-				echo esc_html_x( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.', 'Sample content for the subheading for this pattern.', 'twentytwentyfour' );
-			?></p>
+			<p class="has-text-align-center"><?php echo esc_html_x( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers.', 'Sample content for the subheading for this pattern.', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->
@@ -37,30 +33,22 @@
 			<!-- wp:column {"verticalAlignment":"center","width":"40%"} -->
 			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:40%">
 				<!-- wp:heading {"level":3,"className":"is-style-asterisk"} -->
-				<h3 class="wp-block-heading is-style-asterisk"><?php
-					echo esc_html_x( 'Études Architect App', 'A heading for the list.', 'twentytwentyfour' );
-				?></h3>
+				<h3 class="wp-block-heading is-style-asterisk"><?php echo esc_html_x( 'Études Architect App', 'A heading for the list.', 'twentytwentyfour' ); ?></h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:list {"style":{"typography":{"lineHeight":"1.75"}},"className":"is-style-checkmark-list"} -->
 				<ul class="is-style-checkmark-list" style="line-height:1.75">
 
 					<!-- wp:list-item -->
-					<li><?php
-						echo esc_html_x( 'Collaborate with fellow architects.', 'A general list item.', 'twentytwentyfour' );
-					?></li>
+					<li><?php echo esc_html_x( 'Collaborate with fellow architects.', 'A general list item.', 'twentytwentyfour' ); ?></li>
 					<!-- /wp:list-item -->
 
 					<!-- wp:list-item -->
-					<li><?php
-						echo esc_html_x( 'Showcase your projects.', 'A general list item.', 'twentytwentyfour' );
-					?></li>
+					<li><?php echo esc_html_x( 'Showcase your projects.', 'A general list item.', 'twentytwentyfour' ); ?></li>
 					<!-- /wp:list-item -->
 
 					<!-- wp:list-item -->
-					<li><?php
-						echo esc_html_x( 'Experience the world of architecture.', 'A general list item.', 'twentytwentyfour' );
-					?></li>
+					<li><?php echo esc_html_x( 'Experience the world of architecture.', 'A general list item.', 'twentytwentyfour' ); ?></li>
 					<!-- /wp:list-item -->
 
 				</ul>
@@ -99,29 +87,21 @@
 			<!-- wp:column {"verticalAlignment":"center","width":"40%"} -->
 			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:40%">
 				<!-- wp:heading {"level":3,"className":"is-style-asterisk"} -->
-				<h3 class="wp-block-heading is-style-asterisk"><?php
-					echo esc_html_x( 'Études Newsletter', 'A heading for the list.', 'twentytwentyfour' );
-				?></h3>
+				<h3 class="wp-block-heading is-style-asterisk"><?php echo esc_html_x( 'Études Newsletter', 'A heading for the list.', 'twentytwentyfour' ); ?></h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:list {"style":{"typography":{"lineHeight":"1.75"}},"className":"is-style-checkmark-list"} -->
 				<ul class="is-style-checkmark-list" style="line-height:1.75">
 					<!-- wp:list-item -->
-					<li><?php
-						echo esc_html_x( 'A world of thought-provoking articles.', 'A general list item.', 'twentytwentyfour' );
-					?></li>
+					<li><?php echo esc_html_x( 'A world of thought-provoking articles.', 'A general list item.', 'twentytwentyfour' ); ?></li>
 					<!-- /wp:list-item -->
 
 					<!-- wp:list-item -->
-					<li><?php
-						echo esc_html_x( 'Case studies that celebrate architecture.', 'A general list item.', 'twentytwentyfour' );
-					?></li>
+					<li><?php echo esc_html_x( 'Case studies that celebrate architecture.', 'A general list item.', 'twentytwentyfour' ); ?></li>
 					<!-- /wp:list-item -->
 
 					<!-- wp:list-item -->
-					<li><?php
-						echo esc_html_x( 'Exclusive access to design insights.', 'A general list item.', 'twentytwentyfour' );
-					?></li>
+					<li><?php echo esc_html_x( 'Exclusive access to design insights.', 'A general list item.', 'twentytwentyfour' ); ?></li>
 					<!-- /wp:list-item -->
 				</ul>
 				<!-- /wp:list -->

--- a/patterns/footer-portfolio.php
+++ b/patterns/footer-portfolio.php
@@ -89,7 +89,7 @@
 			<!-- /wp:group -->
 			<!-- wp:paragraph {"fontSize":"small"} -->
 			<p class="has-small-font-size">
-				<?php 
+				<?php
 				/* Translators: WordPress link. */
 				$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfour' ) ) . '" rel="nofollow">WordPress</a>';
 				echo sprintf(

--- a/patterns/footer-portfolio.php
+++ b/patterns/footer-portfolio.php
@@ -26,9 +26,7 @@
 			<!-- wp:column {"width":"57%"} -->
 			<div class="wp-block-column" style="flex-basis:57%">
 				<!-- wp:heading {"fontSize":"x-large"} -->
-				<h2 class="wp-block-heading has-x-large-font-size"><?php
-					esc_html_e( 'Keep up, get in touch.', 'twentytwentyfour' );
-				?></h2>
+				<h2 class="wp-block-heading has-x-large-font-size"><?php esc_html_e( 'Keep up, get in touch.', 'twentytwentyfour' ); ?></h2>
 				<!-- /wp:heading -->
 			</div>
 			<!-- /wp:column -->
@@ -37,15 +35,11 @@
 				<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 				<div class="wp-block-group">
 					<!-- wp:heading {"level":3,"fontSize":"medium","fontFamily":"body"} -->
-					<h3 class="wp-block-heading has-body-font-family has-medium-font-size"><?php
-						esc_html_e( 'Contact Me', 'twentytwentyfour' );
-					?></h3>
+					<h3 class="wp-block-heading has-body-font-family has-medium-font-size"><?php esc_html_e( 'Contact Me', 'twentytwentyfour' ); ?></h3>
 					<!-- /wp:heading -->
 					<!-- wp:paragraph -->
 					<p>
-						<a href="#"><?php
-							echo esc_html_x( 'info@example.com', 'Example email in site footer', 'twentytwentyfour' );
-						?></a>
+						<a href="#"><?php echo esc_html_x( 'info@example.com', 'Example email in site footer', 'twentytwentyfour' ); ?></a>
 					</p>
 					<!-- /wp:paragraph -->
 				</div>
@@ -61,17 +55,11 @@
 						<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 						<div class="wp-block-group">
 							<!-- wp:heading {"level":3,"fontSize":"medium","fontFamily":"body"} -->
-							<h3 class="wp-block-heading has-body-font-family has-medium-font-size"><?php
-								esc_html_e( 'Follow Me', 'twentytwentyfour' );
-							?></h3>
+							<h3 class="wp-block-heading has-body-font-family has-medium-font-size"><?php esc_html_e( 'Follow Me', 'twentytwentyfour' ); ?></h3>
 							<!-- /wp:heading -->
 							<!-- wp:paragraph -->
 							<p>
-								<a href="#"><?php
-									esc_html_e( 'Instagram', 'twentytwentyfour' );
-								?></a> / <a href="#"><?php 
-									esc_html_e( 'Facebook', 'twentytwentyfour' );
-								?></a>
+								<a href="#"><?php esc_html_e( 'Instagram', 'twentytwentyfour' ); ?></a> / <a href="#"><?php esc_html_e( 'Facebook', 'twentytwentyfour' ); ?></a>
 							</p>
 							<!-- /wp:paragraph -->
 						</div>
@@ -94,23 +82,20 @@
 			<!-- wp:group {"style":{"spacing":{"blockGap":"6px"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 			<div class="wp-block-group">
 				<!-- wp:paragraph {"fontSize":"small"} -->
-				<p class="has-small-font-size"><?php
-					esc_html_e( '&copy;', 'twentytwentyfour' );
-				?></p>
+				<p class="has-small-font-size"><?php esc_html_e( '&copy;', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 				<!-- wp:site-title {"level":0,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} /-->
 			</div>
 			<!-- /wp:group -->
 			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size"><?php
-				/* Translators: WordPress link. */
+			<p class="has-small-font-size"><?php /* Translators: WordPress link. */
 				$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfour' ) ) . '" rel="nofollow">WordPress</a>';
 				echo sprintf(
 					/* Translators: Designed with WordPress */
 					esc_html__( 'Designed with %1$s', 'twentytwentyfour' ),
 					$wordpress_link
 				);
-			?></p>
+				?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/footer-portfolio.php
+++ b/patterns/footer-portfolio.php
@@ -88,14 +88,17 @@
 			</div>
 			<!-- /wp:group -->
 			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size"><?php /* Translators: WordPress link. */
+			<p class="has-small-font-size">
+				<?php 
+				/* Translators: WordPress link. */
 				$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfour' ) ) . '" rel="nofollow">WordPress</a>';
 				echo sprintf(
 					/* Translators: Designed with WordPress */
 					esc_html__( 'Designed with %1$s', 'twentytwentyfour' ),
 					$wordpress_link
 				);
-				?></p>
+				?>
+			</p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/footer-portfolio.php
+++ b/patterns/footer-portfolio.php
@@ -26,9 +26,9 @@
 			<!-- wp:column {"width":"57%"} -->
 			<div class="wp-block-column" style="flex-basis:57%">
 				<!-- wp:heading {"fontSize":"x-large"} -->
-				<h2 class="wp-block-heading has-x-large-font-size">
-					<?php esc_html_e( 'Keep up, get in touch.', 'twentytwentyfour' ); ?>
-				</h2>
+				<h2 class="wp-block-heading has-x-large-font-size"><?php
+					esc_html_e( 'Keep up, get in touch.', 'twentytwentyfour' );
+				?></h2>
 				<!-- /wp:heading -->
 			</div>
 			<!-- /wp:column -->
@@ -37,15 +37,15 @@
 				<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 				<div class="wp-block-group">
 					<!-- wp:heading {"level":3,"fontSize":"medium","fontFamily":"body"} -->
-					<h3 class="wp-block-heading has-body-font-family has-medium-font-size">
-						<?php esc_html_e( 'Contact Me', 'twentytwentyfour' ); ?>
-					</h3>
+					<h3 class="wp-block-heading has-body-font-family has-medium-font-size"><?php
+						esc_html_e( 'Contact Me', 'twentytwentyfour' );
+					?></h3>
 					<!-- /wp:heading -->
 					<!-- wp:paragraph -->
 					<p>
-						<a href="#">
-							<?php echo esc_html_x( 'info@example.com', 'Example email in site footer', 'twentytwentyfour' ); ?>
-						</a>
+						<a href="#"><?php
+							echo esc_html_x( 'info@example.com', 'Example email in site footer', 'twentytwentyfour' );
+						?></a>
 					</p>
 					<!-- /wp:paragraph -->
 				</div>
@@ -61,17 +61,17 @@
 						<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 						<div class="wp-block-group">
 							<!-- wp:heading {"level":3,"fontSize":"medium","fontFamily":"body"} -->
-							<h3 class="wp-block-heading has-body-font-family has-medium-font-size">
-								<?php esc_html_e( 'Follow Me', 'twentytwentyfour' ); ?>
-							</h3>
+							<h3 class="wp-block-heading has-body-font-family has-medium-font-size"><?php
+								esc_html_e( 'Follow Me', 'twentytwentyfour' );
+							?></h3>
 							<!-- /wp:heading -->
 							<!-- wp:paragraph -->
 							<p>
-								<a href="#">
-									<?php esc_html_e( 'Instagram', 'twentytwentyfour' ); ?>
-								</a> / <a href="#">
-									<?php esc_html_e( 'Facebook', 'twentytwentyfour' ); ?>
-								</a>
+								<a href="#"><?php
+									esc_html_e( 'Instagram', 'twentytwentyfour' );
+								?></a> / <a href="#"><?php 
+									esc_html_e( 'Facebook', 'twentytwentyfour' );
+								?></a>
 							</p>
 							<!-- /wp:paragraph -->
 						</div>
@@ -94,16 +94,15 @@
 			<!-- wp:group {"style":{"spacing":{"blockGap":"6px"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 			<div class="wp-block-group">
 				<!-- wp:paragraph {"fontSize":"small"} -->
-				<p class="has-small-font-size">
-					<?php esc_html_e( '&copy;', 'twentytwentyfour' ); ?>
-				</p>
+				<p class="has-small-font-size"><?php
+					esc_html_e( '&copy;', 'twentytwentyfour' );
+				?></p>
 				<!-- /wp:paragraph -->
 				<!-- wp:site-title {"level":0,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} /-->
 			</div>
 			<!-- /wp:group -->
 			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size">
-				<?php
+			<p class="has-small-font-size"><?php
 				/* Translators: WordPress link. */
 				$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfour' ) ) . '" rel="nofollow">WordPress</a>';
 				echo sprintf(
@@ -111,8 +110,7 @@
 					esc_html__( 'Designed with %1$s', 'twentytwentyfour' ),
 					$wordpress_link
 				);
-				?>
-			</p>
+			?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/footer-writer.php
+++ b/patterns/footer-writer.php
@@ -15,15 +15,17 @@
 	<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","justifyContent":"center"},"fontSize":"small"} /-->
 
 	<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"secondary","fontSize":"small"} -->
-	<p class="has-text-align-center has-secondary-color has-text-color has-link-color has-small-font-size"><?php
-		/* Translators: WordPress link. */
+	<p class="has-text-align-center has-secondary-color has-text-color has-link-color has-small-font-size">
+	<?php
+	/* Translators: WordPress link. */
 		$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfour' ) ) . '" rel="nofollow">WordPress</a>';
 		echo sprintf(
 			/* Translators: Designed with WordPress */
 			esc_html__( 'Designed with %1$s', 'twentytwentyfour' ),
 			$wordpress_link
 		);
-	?></p>
+		?>
+	</p>
 	<!-- /wp:paragraph -->
 </div>
 <!-- /wp:group -->

--- a/patterns/footer-writer.php
+++ b/patterns/footer-writer.php
@@ -15,8 +15,7 @@
 	<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","justifyContent":"center"},"fontSize":"small"} /-->
 
 	<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"secondary","fontSize":"small"} -->
-	<p class="has-text-align-center has-secondary-color has-text-color has-link-color has-small-font-size">
-		<?php
+	<p class="has-text-align-center has-secondary-color has-text-color has-link-color has-small-font-size"><?php
 		/* Translators: WordPress link. */
 		$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfour' ) ) . '" rel="nofollow">WordPress</a>';
 		echo sprintf(
@@ -24,8 +23,7 @@
 			esc_html__( 'Designed with %1$s', 'twentytwentyfour' ),
 			$wordpress_link
 		);
-		?>
-	</p>
+	?></p>
 	<!-- /wp:paragraph -->
 </div>
 <!-- /wp:group -->

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -37,9 +37,9 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 				<div class="wp-block-group">
 					<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontFamily":"body"} -->
-					<h2 class="wp-block-heading has-medium-font-size has-body-font-family" style="font-style:normal;font-weight:600">
-						<?php esc_html_e( 'About', 'twentytwentyfour' ); ?>
-					</h2>
+					<h2 class="wp-block-heading has-medium-font-size has-body-font-family" style="font-style:normal;font-weight:600"><?php
+						esc_html_e( 'About', 'twentytwentyfour' );
+					?></h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
@@ -62,9 +62,9 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 				<div class="wp-block-group">
 					<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontFamily":"body"} -->
-					<h2 class="wp-block-heading has-medium-font-size has-body-font-family" style="font-style:normal;font-weight:600">
-						<?php esc_html_e( 'Privacy', 'twentytwentyfour' ); ?>
-					</h2>
+					<h2 class="wp-block-heading has-medium-font-size has-body-font-family" style="font-style:normal;font-weight:600"><?php
+						esc_html_e( 'Privacy', 'twentytwentyfour' );
+					?></h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
@@ -86,9 +86,9 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 				<div class="wp-block-group">
 					<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontFamily":"body"} -->
-					<h2 class="wp-block-heading has-medium-font-size has-body-font-family" style="font-style:normal;font-weight:600">
-						<?php esc_html_e( 'Social Media', 'twentytwentyfour' ); ?>
-					</h2>
+					<h2 class="wp-block-heading has-medium-font-size has-body-font-family" style="font-style:normal;font-weight:600"><?php
+						esc_html_e( 'Social Media', 'twentytwentyfour' );
+					?></h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
@@ -116,9 +116,7 @@
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"0"}}}} -->
 	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:0">
 		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast-2","fontSize":"small"} -->
-		<p class="has-contrast-2-color has-text-color has-link-color has-small-font-size">
-
-			<?php
+		<p class="has-contrast-2-color has-text-color has-link-color has-small-font-size"><?php
 			/* Translators: WordPress link. */
 			$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfour' ) ) . '" rel="nofollow">WordPress</a>';
 			echo sprintf(
@@ -126,8 +124,7 @@
 				esc_html__( 'Designed with %1$s', 'twentytwentyfour' ),
 				$wordpress_link
 			);
-			?>
-		</p>
+		?></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -37,9 +37,7 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 				<div class="wp-block-group">
 					<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontFamily":"body"} -->
-					<h2 class="wp-block-heading has-medium-font-size has-body-font-family" style="font-style:normal;font-weight:600"><?php
-						esc_html_e( 'About', 'twentytwentyfour' );
-					?></h2>
+					<h2 class="wp-block-heading has-medium-font-size has-body-font-family" style="font-style:normal;font-weight:600"><?php esc_html_e( 'About', 'twentytwentyfour' ); ?></h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
@@ -62,9 +60,7 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 				<div class="wp-block-group">
 					<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontFamily":"body"} -->
-					<h2 class="wp-block-heading has-medium-font-size has-body-font-family" style="font-style:normal;font-weight:600"><?php
-						esc_html_e( 'Privacy', 'twentytwentyfour' );
-					?></h2>
+					<h2 class="wp-block-heading has-medium-font-size has-body-font-family" style="font-style:normal;font-weight:600"><?php esc_html_e( 'Privacy', 'twentytwentyfour' ); ?></h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
@@ -86,9 +82,7 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 				<div class="wp-block-group">
 					<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontFamily":"body"} -->
-					<h2 class="wp-block-heading has-medium-font-size has-body-font-family" style="font-style:normal;font-weight:600"><?php
-						esc_html_e( 'Social Media', 'twentytwentyfour' );
-					?></h2>
+					<h2 class="wp-block-heading has-medium-font-size has-body-font-family" style="font-style:normal;font-weight:600"><?php esc_html_e( 'Social Media', 'twentytwentyfour' ); ?></h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
@@ -124,7 +118,8 @@
 				esc_html__( 'Designed with %1$s', 'twentytwentyfour' ),
 				$wordpress_link
 			);
-		?></p>
+			?>
+		</p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -110,7 +110,8 @@
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"0"}}}} -->
 	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:0">
 		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast-2","fontSize":"small"} -->
-		<p class="has-contrast-2-color has-text-color has-link-color has-small-font-size"><?php
+		<p class="has-contrast-2-color has-text-color has-link-color has-small-font-size">
+		<?php
 			/* Translators: WordPress link. */
 			$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfour' ) ) . '" rel="nofollow">WordPress</a>';
 			echo sprintf(

--- a/patterns/hero.php
+++ b/patterns/hero.php
@@ -12,9 +12,9 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 	<div class="wp-block-group">
 		<!-- wp:heading {"textAlign":"center","fontSize":"x-large","level":1} -->
-		<h1 class="wp-block-heading has-text-align-center has-x-large-font-size">
-			<?php echo esc_html_x( 'A commitment to innovation and sustainability', 'Heading of the hero section', 'twentytwentyfour' ); ?>
-		</h1>
+		<h1 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php
+			echo esc_html_x( 'A commitment to innovation and sustainability', 'Heading of the hero section', 'twentytwentyfour' );
+		?></h1>
 		<!-- /wp:heading -->
 
 		<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
@@ -22,9 +22,9 @@
 		<!-- /wp:spacer -->
 
 		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center">
-			<?php echo esc_html_x( 'Études is a pioneering firm that seamlessly merges creativity and functionality to redefine architectural excellence.', 'Content of the hero section', 'twentytwentyfour' ); ?>
-		</p>
+		<p class="has-text-align-center"><?php
+			echo esc_html_x( 'Études is a pioneering firm that seamlessly merges creativity and functionality to redefine architectural excellence.', 'Content of the hero section', 'twentytwentyfour' );
+		?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
@@ -35,9 +35,9 @@
 		<div class="wp-block-buttons">
 			<!-- wp:button -->
 			<div class="wp-block-button">
-				<a class="wp-block-button__link wp-element-button">
-					<?php echo esc_html_x( 'About us', 'Button\'s label of the hero section', 'twentytwentyfour' ); ?>
-				</a>
+				<a class="wp-block-button__link wp-element-button"><?php
+					echo esc_html_x( 'About us', 'Button\'s label of the hero section', 'twentytwentyfour' );
+				?></a>
 			</div>
 			<!-- /wp:button -->
 		</div>

--- a/patterns/hero.php
+++ b/patterns/hero.php
@@ -12,9 +12,7 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 	<div class="wp-block-group">
 		<!-- wp:heading {"textAlign":"center","fontSize":"x-large","level":1} -->
-		<h1 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php
-			echo esc_html_x( 'A commitment to innovation and sustainability', 'Heading of the hero section', 'twentytwentyfour' );
-		?></h1>
+		<h1 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html_x( 'A commitment to innovation and sustainability', 'Heading of the hero section', 'twentytwentyfour' ); ?></h1>
 		<!-- /wp:heading -->
 
 		<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
@@ -22,9 +20,7 @@
 		<!-- /wp:spacer -->
 
 		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center"><?php
-			echo esc_html_x( 'Études is a pioneering firm that seamlessly merges creativity and functionality to redefine architectural excellence.', 'Content of the hero section', 'twentytwentyfour' );
-		?></p>
+		<p class="has-text-align-center"><?php echo esc_html_x( 'Études is a pioneering firm that seamlessly merges creativity and functionality to redefine architectural excellence.', 'Content of the hero section', 'twentytwentyfour' ); ?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
@@ -35,9 +31,7 @@
 		<div class="wp-block-buttons">
 			<!-- wp:button -->
 			<div class="wp-block-button">
-				<a class="wp-block-button__link wp-element-button"><?php
-					echo esc_html_x( 'About us', 'Button\'s label of the hero section', 'twentytwentyfour' );
-				?></a>
+				<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'About us', 'Button\'s label of the hero section', 'twentytwentyfour' ); ?></a>
 			</div>
 			<!-- /wp:button -->
 		</div>

--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -10,6 +10,6 @@
 <h1 class="wp-block-heading" id="page-not-found"><?php echo esc_html_x( 'Page Not Found', 'Heading for a webpage that is not found', 'twentytwentyfour' ); ?></h1>
 <!-- /wp:heading -->
 <!-- wp:paragraph -->
-<p><?php echo esc_html_x( 'The page you are looking for doesn’t exist, or it has been moved. Please try searching using the form below.', 'Message to convey that a webpage could not be found', 'twentytwentyfour'); ?></p>
+<p><?php echo esc_html_x( 'The page you are looking for doesn’t exist, or it has been moved. Please try searching using the form below.', 'Message to convey that a webpage could not be found', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->
 <!-- wp:pattern {"slug":"twentytwentyfour/search"} /-->

--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -7,13 +7,9 @@
 ?>
 
 <!-- wp:heading {"level":1} -->
-<h1 class="wp-block-heading" id="page-not-found"><?php
-	echo esc_html_x( 'Page Not Found', 'Heading for a webpage that is not found', 'twentytwentyfour' );
-?></h1>
+<h1 class="wp-block-heading" id="page-not-found"><?php echo esc_html_x( 'Page Not Found', 'Heading for a webpage that is not found', 'twentytwentyfour' ); ?></h1>
 <!-- /wp:heading -->
 <!-- wp:paragraph -->
-<p><?php
-	echo esc_html_x( 'The page you are looking for doesn’t exist, or it has been moved. Please try searching using the form below.', 'Message to convey that a webpage could not be found', 'twentytwentyfour');
-?></p>
+<p><?php echo esc_html_x( 'The page you are looking for doesn’t exist, or it has been moved. Please try searching using the form below.', 'Message to convey that a webpage could not be found', 'twentytwentyfour'); ?></p>
 <!-- /wp:paragraph -->
 <!-- wp:pattern {"slug":"twentytwentyfour/search"} /-->

--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -7,13 +7,13 @@
 ?>
 
 <!-- wp:heading {"level":1} -->
-<h1 class="wp-block-heading" id="page-not-found">
-	<?php echo esc_html_x( 'Page Not Found', 'Heading for a webpage that is not found', 'twentytwentyfour' ); ?>
-</h1>
+<h1 class="wp-block-heading" id="page-not-found"><?php
+	echo esc_html_x( 'Page Not Found', 'Heading for a webpage that is not found', 'twentytwentyfour' );
+?></h1>
 <!-- /wp:heading -->
 <!-- wp:paragraph -->
-<p>
-	<?php echo esc_html_x( 'The page you are looking for doesn’t exist, or it has been moved. Please try searching using the form below.', 'Message to convey that a webpage could not be found', 'twentytwentyfour' ); ?>
-</p>
+<p><?php
+	echo esc_html_x( 'The page you are looking for doesn’t exist, or it has been moved. Please try searching using the form below.', 'Message to convey that a webpage could not be found', 'twentytwentyfour');
+?></p>
 <!-- /wp:paragraph -->
 <!-- wp:pattern {"slug":"twentytwentyfour/search"} /-->

--- a/patterns/hidden-comments.php
+++ b/patterns/hidden-comments.php
@@ -9,9 +9,9 @@
 <!-- wp:comments {"className":"wp-block-comments-query-loop"} -->
 <div class="wp-block-comments wp-block-comments-query-loop">
 	<!-- wp:heading -->
-	<h2>
-		<?php esc_html_e( 'Comments', 'twentytwentyfour' ); ?>
-	</h2>
+	<h2><?php
+		esc_html_e( 'Comments', 'twentytwentyfour' );
+	?></h2>
 	<!-- /wp:heading -->
 	<!-- wp:comments-title {"level":3} /-->
 	<!-- wp:comment-template -->

--- a/patterns/hidden-comments.php
+++ b/patterns/hidden-comments.php
@@ -9,9 +9,7 @@
 <!-- wp:comments {"className":"wp-block-comments-query-loop"} -->
 <div class="wp-block-comments wp-block-comments-query-loop">
 	<!-- wp:heading -->
-	<h2><?php
-		esc_html_e( 'Comments', 'twentytwentyfour' );
-	?></h2>
+	<h2><?php esc_html_e( 'Comments', 'twentytwentyfour' ); ?></h2>
 	<!-- /wp:heading -->
 	<!-- wp:comments-title {"level":3} /-->
 	<!-- wp:comment-template -->

--- a/patterns/hidden-intro-text-left.php
+++ b/patterns/hidden-intro-text-left.php
@@ -14,7 +14,9 @@
 <!-- wp:group {"align":"wide","layout":{"type":"constrained","justifyContent":"left","contentSize":"890px"}} -->
 <div class="wp-block-group alignwide">
 	<!-- wp:heading {"level":1,"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"xx-large"} -->
-	<h1 class="wp-block-heading has-xx-large-font-size" style="line-height:1.2"><?php echo wp_kses_post( __( 'I’m <em>Leia Acosta</em>, a passionate photographer who finds inspiration in capturing the fleeting beauty of life.' ) ); ?></h1>
+	<h1 class="wp-block-heading has-xx-large-font-size" style="line-height:1.2"><?php 
+		echo wp_kses_post( __( 'I’m <em>Leia Acosta</em>, a passionate photographer who finds inspiration in capturing the fleeting beauty of life.' ) ); 
+	?></h1>
 	<!-- /wp:heading -->
 </div>
 <!-- /wp:group -->

--- a/patterns/hidden-intro-text-left.php
+++ b/patterns/hidden-intro-text-left.php
@@ -14,9 +14,7 @@
 <!-- wp:group {"align":"wide","layout":{"type":"constrained","justifyContent":"left","contentSize":"890px"}} -->
 <div class="wp-block-group alignwide">
 	<!-- wp:heading {"level":1,"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"xx-large"} -->
-	<h1 class="wp-block-heading has-xx-large-font-size" style="line-height:1.2"><?php 
-		echo wp_kses_post( __( 'I’m <em>Leia Acosta</em>, a passionate photographer who finds inspiration in capturing the fleeting beauty of life.' ) ); 
-	?></h1>
+	<h1 class="wp-block-heading has-xx-large-font-size" style="line-height:1.2"><?php echo wp_kses_post( __( 'I’m <em>Leia Acosta</em>, a passionate photographer who finds inspiration in capturing the fleeting beauty of life.' ) ); ?></h1>
 	<!-- /wp:heading -->
 </div>
 <!-- /wp:group -->

--- a/patterns/hidden-no-results-content.php
+++ b/patterns/hidden-no-results-content.php
@@ -6,7 +6,7 @@
  */
 ?>
 <!-- wp:paragraph -->
-<p>
-	<?php echo esc_html_x( 'No posts were found.', 'Message explaining that there are no results returned from a search', 'twentytwentyfour' ); ?>
-</p>
+<p><?php
+	echo esc_html_x( 'No posts were found.', 'Message explaining that there are no results returned from a search', 'twentytwentyfour' );
+?></p>
 <!-- /wp:paragraph -->

--- a/patterns/hidden-no-results-content.php
+++ b/patterns/hidden-no-results-content.php
@@ -6,7 +6,5 @@
  */
 ?>
 <!-- wp:paragraph -->
-<p><?php
-	echo esc_html_x( 'No posts were found.', 'Message explaining that there are no results returned from a search', 'twentytwentyfour' );
-?></p>
+<p><?php echo esc_html_x( 'No posts were found.', 'Message explaining that there are no results returned from a search', 'twentytwentyfour' ); ?></p>
 <!-- /wp:paragraph -->

--- a/patterns/hidden-post-meta.php
+++ b/patterns/hidden-post-meta.php
@@ -17,9 +17,7 @@
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"fontSize":"small","textColor":"contrast-2"} -->
-		<p class="has-small-font-size has-contrast-2-color has-text-color"><?php
-			echo esc_html_x( 'by', 'Prefix for the post author block: By author name', 'twentytwentyfour' );
-		?></p>
+		<p class="has-small-font-size has-contrast-2-color has-text-color"><?php echo esc_html_x( 'by', 'Prefix for the post author block: By author name', 'twentytwentyfour' ); ?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:post-author-name {"isLink":true} /-->

--- a/patterns/hidden-post-meta.php
+++ b/patterns/hidden-post-meta.php
@@ -17,9 +17,9 @@
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"fontSize":"small","textColor":"contrast-2"} -->
-		<p class="has-small-font-size has-contrast-2-color has-text-color">
-			<?php echo esc_html_x( 'by', 'Prefix for the post author block: By author name', 'twentytwentyfour' ); ?>
-		</p>
+		<p class="has-small-font-size has-contrast-2-color has-text-color"><?php
+			echo esc_html_x( 'by', 'Prefix for the post author block: By author name', 'twentytwentyfour' );
+		?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:post-author-name {"isLink":true} /-->

--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -15,9 +15,9 @@
 		<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 		<div class="wp-block-group">
 			<!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
-			<h2 class="wp-block-heading" style="font-size:1.6rem">
-				<?php esc_html_e( 'About the author', 'twentytwentyfour' ); ?>
-			</h2>
+			<h2 class="wp-block-heading" style="font-size:1.6rem"><?php
+				esc_html_e( 'About the author', 'twentytwentyfour' );
+			?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:post-author-biography {"fontSize":"small"} /-->
@@ -33,9 +33,9 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
 		<!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
-		<h2 class="wp-block-heading" style="font-size:1.6rem">
-			<?php esc_html_e( 'Popular Categories', 'twentytwentyfour' ); ?>
-		</h2>
+		<h2 class="wp-block-heading" style="font-size:1.6rem"><?php
+			esc_html_e( 'Popular Categories', 'twentytwentyfour' );
+		?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:categories {"showHierarchy":true,"showPostCounts":true,"fontSize":"small"} /-->
@@ -51,15 +51,15 @@
 		<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 		<div class="wp-block-group">
 			<!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
-			<h2 class="wp-block-heading" style="font-size:1.6rem">
-				<?php esc_html_e( 'Useful Links', 'twentytwentyfour' ); ?>
-			</h2>
+			<h2 class="wp-block-heading" style="font-size:1.6rem"><?php
+				esc_html_e( 'Useful Links', 'twentytwentyfour' );
+			?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size">
-				<?php esc_html_e( 'Links I found useful and wanted to share.', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-small-font-size"><?php
+				esc_html_e( 'Links I found useful and wanted to share.', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->
@@ -78,9 +78,9 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 	<div class="wp-block-group">
 		<!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
-		<h2 class="wp-block-heading" style="font-size:1.6rem">
-			<?php esc_html_e( 'Search the website', 'twentytwentyfour' ); ?>
-		</h2>
+		<h2 class="wp-block-heading" style="font-size:1.6rem"><?php
+			esc_html_e( 'Search the website', 'twentytwentyfour' );
+		?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:search {"label":"<?php echo esc_attr_x( 'Search', 'search form label', 'twentytwentyfour' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Search...', 'search form placeholder', 'twentytwentyfour' ); ?>","width":100,"widthUnit":"%","buttonText":"<?php echo esc_attr_x( 'Search', 'search form label', 'twentytwentyfour' ); ?>"} /-->

--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -15,9 +15,7 @@
 		<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 		<div class="wp-block-group">
 			<!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
-			<h2 class="wp-block-heading" style="font-size:1.6rem"><?php
-				esc_html_e( 'About the author', 'twentytwentyfour' );
-			?></h2>
+			<h2 class="wp-block-heading" style="font-size:1.6rem"><?php esc_html_e( 'About the author', 'twentytwentyfour' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:post-author-biography {"fontSize":"small"} /-->
@@ -33,9 +31,7 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
 		<!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
-		<h2 class="wp-block-heading" style="font-size:1.6rem"><?php
-			esc_html_e( 'Popular Categories', 'twentytwentyfour' );
-		?></h2>
+		<h2 class="wp-block-heading" style="font-size:1.6rem"><?php esc_html_e( 'Popular Categories', 'twentytwentyfour' ); ?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:categories {"showHierarchy":true,"showPostCounts":true,"fontSize":"small"} /-->
@@ -51,15 +47,11 @@
 		<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 		<div class="wp-block-group">
 			<!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
-			<h2 class="wp-block-heading" style="font-size:1.6rem"><?php
-				esc_html_e( 'Useful Links', 'twentytwentyfour' );
-			?></h2>
+			<h2 class="wp-block-heading" style="font-size:1.6rem"><?php esc_html_e( 'Useful Links', 'twentytwentyfour' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size"><?php
-				esc_html_e( 'Links I found useful and wanted to share.', 'twentytwentyfour' );
-			?></p>
+			<p class="has-small-font-size"><?php esc_html_e( 'Links I found useful and wanted to share.', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->
@@ -78,9 +70,7 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 	<div class="wp-block-group">
 		<!-- wp:heading {"style":{"typography":{"fontSize":"1.6rem"}}} -->
-		<h2 class="wp-block-heading" style="font-size:1.6rem"><?php
-			esc_html_e( 'Search the website', 'twentytwentyfour' );
-		?></h2>
+		<h2 class="wp-block-heading" style="font-size:1.6rem"><?php esc_html_e( 'Search the website', 'twentytwentyfour' ); ?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:search {"label":"<?php echo esc_attr_x( 'Search', 'search form label', 'twentytwentyfour' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Search...', 'search form placeholder', 'twentytwentyfour' ); ?>","width":100,"widthUnit":"%","buttonText":"<?php echo esc_attr_x( 'Search', 'search form label', 'twentytwentyfour' ); ?>"} /-->

--- a/patterns/left-aligned-cta-image.php
+++ b/patterns/left-aligned-cta-image.php
@@ -14,29 +14,29 @@
 		<!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
 		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
 			<!-- wp:heading -->
-			<h2 class="wp-block-heading">
-				<?php echo esc_html_x( 'Enhance your architectural journey with the Études Architect app.', 'sample heading for call to action', 'twentytwentyfour' ); ?>
-			</h2>
+			<h2 class="wp-block-heading"><?php
+				echo esc_html_x( 'Enhance your architectural journey with the Études Architect app.', 'sample heading for call to action', 'twentytwentyfour' );
+			?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:list {"style":{"typography":{"lineHeight":"1.75"}},"className":"is-style-checkmark-list"} -->
 			<ul class="is-style-checkmark-list" style="line-height:1.75">
 				<!-- wp:list-item -->
-				<li>
-					<?php echo esc_html_x( 'Collaborate with fellow architects.', 'A general list item.', 'twentytwentyfour' ); ?>
-				</li>
+				<li><?php
+					echo esc_html_x( 'Collaborate with fellow architects.', 'A general list item.', 'twentytwentyfour' );
+				?></li>
 				<!-- /wp:list-item -->
 
 				<!-- wp:list-item -->
-				<li>
-					<?php echo esc_html_x( 'Showcase your projects.', 'A general list item.', 'twentytwentyfour' ); ?>
-				</li>
+				<li><?php
+					echo esc_html_x( 'Showcase your projects.', 'A general list item.', 'twentytwentyfour' );
+				?></li>
 				<!-- /wp:list-item -->
 
 				<!-- wp:list-item -->
-				<li>
-					<?php echo esc_html_x( 'Experience the world of architecture.', 'A general list item.', 'twentytwentyfour' ); ?>
-				</li>
+				<li><?php
+					echo esc_html_x( 'Experience the world of architecture.', 'A general list item.', 'twentytwentyfour' );
+				?></li>
 				<!-- /wp:list-item -->
 			</ul>
 			<!-- /wp:list -->
@@ -45,17 +45,17 @@
 			<div class="wp-block-buttons">
 				<!-- wp:button -->
 				<div class="wp-block-button">
-					<a class="wp-block-button__link wp-element-button">
-						<?php echo esc_html_x( 'Download app', 'sample content for call to action button', 'twentytwentyfour' ); ?>
-					</a>
+					<a class="wp-block-button__link wp-element-button"><?php
+						echo esc_html_x( 'Download app', 'sample content for call to action button', 'twentytwentyfour' );
+					?></a>
 				</div>
 				<!-- /wp:button -->
 
 				<!-- wp:button {"className":"is-style-outline"} -->
 				<div class="wp-block-button is-style-outline">
-					<a class="wp-block-button__link wp-element-button">
-						<?php echo esc_html_x( 'How it works', 'sample content for call to action button', 'twentytwentyfour' ); ?>
-					</a>
+					<a class="wp-block-button__link wp-element-button"><?php
+						echo esc_html_x( 'How it works', 'sample content for call to action button', 'twentytwentyfour' );
+					?></a>
 				</div>
 				<!-- /wp:button -->
 			</div>

--- a/patterns/left-aligned-cta-image.php
+++ b/patterns/left-aligned-cta-image.php
@@ -14,29 +14,21 @@
 		<!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
 		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
 			<!-- wp:heading -->
-			<h2 class="wp-block-heading"><?php
-				echo esc_html_x( 'Enhance your architectural journey with the Études Architect app.', 'sample heading for call to action', 'twentytwentyfour' );
-			?></h2>
+			<h2 class="wp-block-heading"><?php echo esc_html_x( 'Enhance your architectural journey with the Études Architect app.', 'sample heading for call to action', 'twentytwentyfour' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:list {"style":{"typography":{"lineHeight":"1.75"}},"className":"is-style-checkmark-list"} -->
 			<ul class="is-style-checkmark-list" style="line-height:1.75">
 				<!-- wp:list-item -->
-				<li><?php
-					echo esc_html_x( 'Collaborate with fellow architects.', 'A general list item.', 'twentytwentyfour' );
-				?></li>
+				<li><?php echo esc_html_x( 'Collaborate with fellow architects.', 'A general list item.', 'twentytwentyfour' ); ?></li>
 				<!-- /wp:list-item -->
 
 				<!-- wp:list-item -->
-				<li><?php
-					echo esc_html_x( 'Showcase your projects.', 'A general list item.', 'twentytwentyfour' );
-				?></li>
+				<li><?php echo esc_html_x( 'Showcase your projects.', 'A general list item.', 'twentytwentyfour' ); ?></li>
 				<!-- /wp:list-item -->
 
 				<!-- wp:list-item -->
-				<li><?php
-					echo esc_html_x( 'Experience the world of architecture.', 'A general list item.', 'twentytwentyfour' );
-				?></li>
+				<li><?php echo esc_html_x( 'Experience the world of architecture.', 'A general list item.', 'twentytwentyfour' ); ?></li>
 				<!-- /wp:list-item -->
 			</ul>
 			<!-- /wp:list -->
@@ -45,17 +37,13 @@
 			<div class="wp-block-buttons">
 				<!-- wp:button -->
 				<div class="wp-block-button">
-					<a class="wp-block-button__link wp-element-button"><?php
-						echo esc_html_x( 'Download app', 'sample content for call to action button', 'twentytwentyfour' );
-					?></a>
+					<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Download app', 'sample content for call to action button', 'twentytwentyfour' ); ?></a>
 				</div>
 				<!-- /wp:button -->
 
 				<!-- wp:button {"className":"is-style-outline"} -->
 				<div class="wp-block-button is-style-outline">
-					<a class="wp-block-button__link wp-element-button"><?php
-						echo esc_html_x( 'How it works', 'sample content for call to action button', 'twentytwentyfour' );
-					?></a>
+					<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'How it works', 'sample content for call to action button', 'twentytwentyfour' ); ?></a>
 				</div>
 				<!-- /wp:button -->
 			</div>

--- a/patterns/page-04-newsletter-landing.php
+++ b/patterns/page-04-newsletter-landing.php
@@ -25,9 +25,7 @@
 		<!-- /wp:spacer -->
 
 		<!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"right":"0","left":"0"},"padding":{"right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast","fontSize":"x-large"} -->
-		<h2 class="wp-block-heading has-text-align-center has-contrast-color has-text-color has-link-color has-x-large-font-size" style="margin-right:0;margin-left:0;padding-right:0;padding-left:0"><?php
-			echo esc_html_x( 'Subscribe to the newsletter and stay connected with our community', 'sample content for newsletter subscription', 'twentytwentyfour' );
-		?></h2>
+		<h2 class="wp-block-heading has-text-align-center has-contrast-color has-text-color has-link-color has-x-large-font-size" style="margin-right:0;margin-left:0;padding-right:0;padding-left:0"><?php echo esc_html_x( 'Subscribe to the newsletter and stay connected with our community', 'sample content for newsletter subscription', 'twentytwentyfour' ); ?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
@@ -38,9 +36,7 @@
 		<div class="wp-block-buttons">
 			<!-- wp:button -->
 			<div class="wp-block-button">
-				<a class="wp-block-button__link wp-element-button"><?php
-					echo esc_html_x( 'Sign up', 'sample content for newsletter subscription button', 'twentytwentyfour' );
-				?></a>
+				<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Sign up', 'sample content for newsletter subscription button', 'twentytwentyfour' ); ?></a>
 			</div>
 			<!-- /wp:button -->
 		</div>

--- a/patterns/page-04-newsletter-landing.php
+++ b/patterns/page-04-newsletter-landing.php
@@ -25,9 +25,9 @@
 		<!-- /wp:spacer -->
 
 		<!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"right":"0","left":"0"},"padding":{"right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast","fontSize":"x-large"} -->
-		<h2 class="wp-block-heading has-text-align-center has-contrast-color has-text-color has-link-color has-x-large-font-size" style="margin-right:0;margin-left:0;padding-right:0;padding-left:0">
-			<?php echo esc_html_x( 'Subscribe to the newsletter and stay connected with our community', 'sample content for newsletter subscription', 'twentytwentyfour' ); ?>
-		</h2>
+		<h2 class="wp-block-heading has-text-align-center has-contrast-color has-text-color has-link-color has-x-large-font-size" style="margin-right:0;margin-left:0;padding-right:0;padding-left:0"><?php
+			echo esc_html_x( 'Subscribe to the newsletter and stay connected with our community', 'sample content for newsletter subscription', 'twentytwentyfour' );
+		?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
@@ -38,9 +38,9 @@
 		<div class="wp-block-buttons">
 			<!-- wp:button -->
 			<div class="wp-block-button">
-				<a class="wp-block-button__link wp-element-button">
-					<?php echo esc_html_x( 'Sign up', 'sample content for newsletter subscription button', 'twentytwentyfour' ); ?>
-				</a>
+				<a class="wp-block-button__link wp-element-button"><?php
+					echo esc_html_x( 'Sign up', 'sample content for newsletter subscription button', 'twentytwentyfour' );
+				?></a>
 			</div>
 			<!-- /wp:button -->
 		</div>

--- a/patterns/page-07-rsvp-landing.php
+++ b/patterns/page-07-rsvp-landing.php
@@ -20,26 +20,20 @@
 			<div class="wp-block-group" style="min-height:100%">
 
 				<!-- wp:heading {"textAlign":"right","level":1,"style":{"typography":{"fontSize":"12rem","writingMode":"vertical-rl","lineHeight":"1"},"spacing":{"margin":{"right":"0","left":"calc( var(--wp--preset--spacing--20) * -1)"}}}} -->
-				<h1 class="wp-block-heading has-text-align-right" style="margin-right:0;margin-left:calc( var(--wp--preset--spacing--20) * -1);font-size:12rem;line-height:1;writing-mode:vertical-rl"><?php
-					echo esc_html_x( 'RSVP', 'Initials for ´please respond´', 'twentytwentyfour' );
-				?></h1>
+				<h1 class="wp-block-heading has-text-align-right" style="margin-right:0;margin-left:calc( var(--wp--preset--spacing--20) * -1);font-size:12rem;line-height:1;writing-mode:vertical-rl"><?php echo esc_html_x( 'RSVP', 'Initials for ´please respond´', 'twentytwentyfour' ); ?></h1>
 				<!-- /wp:heading -->
 
 				<!-- wp:group {"layout":{"type":"constrained","contentSize":"300px","justifyContent":"left"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fixed","flexSize":"50%"}}} -->
-					<p><?php
-						echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Arch Summit, February 2025.', 'RSVP call to action description', 'twentytwentyfour' );
-					?></p>
+					<p><?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Arch Summit, February 2025.', 'RSVP call to action description', 'twentytwentyfour' ); ?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:buttons -->
 					<div class="wp-block-buttons">
 						<!-- wp:button -->
 						<div class="wp-block-button">
-							<a class="wp-block-button__link wp-element-button"><?php
-								echo esc_html_x( 'Reserve your spot', 'Call to action to the reservation', 'twentytwentyfour' );
-							?></a>
+							<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Reserve your spot', 'Call to action to the reservation', 'twentytwentyfour' ); ?></a>
 						</div>
 						<!-- /wp:button -->
 					</div>

--- a/patterns/page-07-rsvp-landing.php
+++ b/patterns/page-07-rsvp-landing.php
@@ -20,26 +20,26 @@
 			<div class="wp-block-group" style="min-height:100%">
 
 				<!-- wp:heading {"textAlign":"right","level":1,"style":{"typography":{"fontSize":"12rem","writingMode":"vertical-rl","lineHeight":"1"},"spacing":{"margin":{"right":"0","left":"calc( var(--wp--preset--spacing--20) * -1)"}}}} -->
-				<h1 class="wp-block-heading has-text-align-right" style="margin-right:0;margin-left:calc( var(--wp--preset--spacing--20) * -1);font-size:12rem;line-height:1;writing-mode:vertical-rl">
-					<?php echo esc_html_x( 'RSVP', 'Initials for ´please respond´', 'twentytwentyfour' ); ?>
-				</h1>
+				<h1 class="wp-block-heading has-text-align-right" style="margin-right:0;margin-left:calc( var(--wp--preset--spacing--20) * -1);font-size:12rem;line-height:1;writing-mode:vertical-rl"><?php
+					echo esc_html_x( 'RSVP', 'Initials for ´please respond´', 'twentytwentyfour' );
+				?></h1>
 				<!-- /wp:heading -->
 
 				<!-- wp:group {"layout":{"type":"constrained","contentSize":"300px","justifyContent":"left"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fixed","flexSize":"50%"}}} -->
-					<p>
-						<?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Arch Summit, February 2025.', 'RSVP call to action description', 'twentytwentyfour' ); ?>
-					</p>
+					<p><?php
+						echo esc_html_x( 'Experience the fusion of imagination and expertise with Études Arch Summit, February 2025.', 'RSVP call to action description', 'twentytwentyfour' );
+					?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:buttons -->
 					<div class="wp-block-buttons">
 						<!-- wp:button -->
 						<div class="wp-block-button">
-							<a class="wp-block-button__link wp-element-button">
-								<?php echo esc_html_x( 'Reserve your spot', 'Call to action to the reservation', 'twentytwentyfour' ); ?>
-							</a>
+							<a class="wp-block-button__link wp-element-button"><?php
+								echo esc_html_x( 'Reserve your spot', 'Call to action to the reservation', 'twentytwentyfour' );
+							?></a>
 						</div>
 						<!-- /wp:button -->
 					</div>

--- a/patterns/posts-featured.php
+++ b/patterns/posts-featured.php
@@ -10,9 +10,7 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
 	<!-- wp:heading {"align":"wide","style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"0"}}},"fontSize":"x-large"} -->
-	<h2 class="wp-block-heading alignwide has-x-large-font-size" style="margin-top:0;line-height:1"><?php
-		esc_html_e( 'Watch, Read, Listen', 'twentytwentyfour' );
-	?></h2>
+	<h2 class="wp-block-heading alignwide has-x-large-font-size" style="margin-top:0;line-height:1"><?php esc_html_e( 'Watch, Read, Listen', 'twentytwentyfour' ); ?></h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:spacer {"height":"var:preset|spacing|10","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->

--- a/patterns/posts-featured.php
+++ b/patterns/posts-featured.php
@@ -10,9 +10,9 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
 	<!-- wp:heading {"align":"wide","style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"0"}}},"fontSize":"x-large"} -->
-	<h2 class="wp-block-heading alignwide has-x-large-font-size" style="margin-top:0;line-height:1">
-		<?php esc_html_e( 'Watch, Read, Listen', 'twentytwentyfour' ); ?>
-	</h2>
+	<h2 class="wp-block-heading alignwide has-x-large-font-size" style="margin-top:0;line-height:1"><?php
+		esc_html_e( 'Watch, Read, Listen', 'twentytwentyfour' );
+	?></h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:spacer {"height":"var:preset|spacing|10","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->

--- a/patterns/pricing.php
+++ b/patterns/pricing.php
@@ -14,15 +14,15 @@
 		<!-- wp:group {"align":"wide","layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 		<div class="wp-block-group alignwide">
 			<!-- wp:heading {"textAlign":"center"} -->
-			<h2 class="wp-block-heading has-text-align-center">
-				<?php echo esc_html_x( 'Our Services', 'Heading for pricing pattern', 'twentytwentyfour' ); ?>
-			</h2>
+			<h2 class="wp-block-heading has-text-align-center"><?php
+				echo esc_html_x( 'Our Services', 'Heading for pricing pattern', 'twentytwentyfour' );
+			?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"1.125rem"},"spacing":{"margin":{"top":"var:preset|spacing|10"}}}} -->
-			<p class="has-text-align-center" style="margin-top:var(--wp--preset--spacing--10);font-size:1.125rem">
-				<?php echo esc_html_x( 'We offer flexible options, which you can adapt to the different needs of each project.', 'Short blurb for pricing pattern', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-text-align-center" style="margin-top:var(--wp--preset--spacing--10);font-size:1.125rem"><?php
+				echo esc_html_x( 'We offer flexible options, which you can adapt to the different needs of each project.', 'Short blurb for pricing pattern', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->
@@ -37,16 +37,16 @@
 			<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--base-3);border-top-width:1px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--30)">
 				<!-- wp:heading {"textAlign":"center","level":4,"style":{"spacing":{"padding":{"top":"1px"}}},"fontSize":"medium"} -->
 				<h4 class="wp-block-heading has-text-align-center has-medium-font-size" style="padding-top:1px">
-					<em>
-						<?php echo esc_html_x( 'Free', 'Title for Free pricing level', 'twentytwentyfour' ); ?>
-					</em>
+					<em><?php
+						echo esc_html_x( 'Free', 'Title for Free pricing level', 'twentytwentyfour' );
+					?></em>
 				</h4>
 				<!-- /wp:heading -->
 
 				<!-- wp:heading {"textAlign":"center","level":5,"fontSize":"x-large"} -->
-				<h5 class="wp-block-heading has-text-align-center has-x-large-font-size">
-					<?php echo esc_html_x( '$0', 'Price for Free pricing level', 'twentytwentyfour' ); ?>
-				</h5>
+				<h5 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php
+					echo esc_html_x( '$0', 'Price for Free pricing level', 'twentytwentyfour' );
+				?></h5>
 				<!-- /wp:heading -->
 
 				<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
@@ -57,8 +57,20 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"align":"center"} -->
-					<p class="has-text-align-center">
-						<?php echo wp_kses_post( _x( 'Access to 5 exclusive <em>Études Articles</em> per month.', 'Feature for pricing level', 'twentytwentyfour' ) ); ?>
+					<p class="has-text-align-center"><?php
+						echo wp_kses_post( _x( 'Access to 5 exclusive <em>Études Articles</em> per month.', 'Feature for pricing level', 'twentytwentyfour' ) );
+					?></p>
+					<!-- /wp:paragraph -->
+
+					<!-- wp:separator {"backgroundColor":"base-3"} -->
+					<hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-base-3-background-color has-background is-style-wide" />
+					<!-- /wp:separator -->
+
+					<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
+					<p class="has-text-align-center has-contrast-2-color has-text-color has-link-color">
+						<s><?php
+							echo esc_html_x( 'Weekly print edition.', 'Feature for pricing level', 'twentytwentyfour' );
+						?></s>
 					</p>
 					<!-- /wp:paragraph -->
 
@@ -68,21 +80,9 @@
 
 					<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
 					<p class="has-text-align-center has-contrast-2-color has-text-color has-link-color">
-						<s>
-							<?php echo esc_html_x( 'Weekly print edition.', 'Feature for pricing level', 'twentytwentyfour' ); ?>
-						</s>
-					</p>
-					<!-- /wp:paragraph -->
-
-					<!-- wp:separator {"backgroundColor":"base-3"} -->
-					<hr class="wp-block-separator has-text-color has-base-3-color has-alpha-channel-opacity has-base-3-background-color has-background is-style-wide" />
-					<!-- /wp:separator -->
-
-					<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
-					<p class="has-text-align-center has-contrast-2-color has-text-color has-link-color">
-						<s>
-							<?php echo wp_kses_post( _x( 'Exclusive access to the <em>Études</em> app for iOS and Android.', 'Feature for pricing level', 'twentytwentyfour' ) ); ?>
-						</s>
+						<s><?php
+							echo wp_kses_post( _x( 'Exclusive access to the <em>Études</em> app for iOS and Android.', 'Feature for pricing level', 'twentytwentyfour' ) );
+						?></s>
 					</p>
 					<!-- /wp:paragraph -->
 				</div>
@@ -97,9 +97,9 @@
 				<div class="wp-block-buttons">
 					<!-- wp:button {"width":100,"className":"is-style-outline"} -->
 					<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-outline">
-						<a class="wp-block-button__link wp-element-button">
-							<?php echo esc_html_x( 'Subscribe', 'Call to action pricing level', 'twentytwentyfour' ); ?>
-						</a>
+						<a class="wp-block-button__link wp-element-button"><?php
+							echo esc_html_x( 'Subscribe', 'Call to action pricing level', 'twentytwentyfour' );
+						?></a>
 					</div>
 					<!-- /wp:button -->
 				</div>
@@ -111,16 +111,16 @@
 			<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--contrast);border-top-width:2px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--30)">
 				<!-- wp:heading {"textAlign":"center","level":4} -->
 				<h4 class="wp-block-heading has-text-align-center">
-					<em>
-						<?php echo esc_html_x( 'Connoisseur', 'Title for Connoisseur pricing level', 'twentytwentyfour' ); ?>
-					</em>
+					<em><?php
+						echo esc_html_x( 'Connoisseur', 'Title for Connoisseur pricing level', 'twentytwentyfour' );
+					?></em>
 				</h4>
 				<!-- /wp:heading -->
 
 				<!-- wp:heading {"textAlign":"center","level":5,"fontSize":"x-large"} -->
-				<h5 class="wp-block-heading has-text-align-center has-x-large-font-size">
-					<?php echo esc_html_x( '$12', 'Price for Connoisseur pricing level', 'twentytwentyfour' ); ?>
-				</h5>
+				<h5 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php
+					echo esc_html_x( '$12', 'Price for Connoisseur pricing level', 'twentytwentyfour' );
+				?></h5>
 				<!-- /wp:heading -->
 
 				<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
@@ -131,9 +131,9 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"align":"center"} -->
-					<p class="has-text-align-center">
-						<?php echo wp_kses_post( _x( 'Access to 20 exclusive <em>Études Articles</em> per month.', 'Feature for pricing level', 'twentytwentyfour' ) ); ?>
-					</p>
+					<p class="has-text-align-center"><?php
+						echo wp_kses_post( _x( 'Access to 20 exclusive <em>Études Articles</em> per month.', 'Feature for pricing level', 'twentytwentyfour' ) );
+					?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:separator {"backgroundColor":"base-3"} -->
@@ -141,9 +141,9 @@
 					<!-- /wp:separator -->
 
 					<!-- wp:paragraph {"align":"center"} -->
-					<p class="has-text-align-center">
-						<?php echo esc_html_x( 'Weekly print edition.', 'Feature for pricing level', 'twentytwentyfour' ); ?>
-					</p>
+					<p class="has-text-align-center"><?php
+						echo esc_html_x( 'Weekly print edition.', 'Feature for pricing level', 'twentytwentyfour' );
+					?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:separator {"backgroundColor":"base-3"} -->
@@ -151,9 +151,9 @@
 					<!-- /wp:separator -->
 
 					<!-- wp:paragraph {"align":"center"} -->
-					<p class="has-text-align-center">
-						<?php echo wp_kses_post( _x( 'Exclusive access to the <em>Études</em> app for iOS and Android.', 'Feature for pricing level', 'twentytwentyfour' ) ); ?>
-					</p>
+					<p class="has-text-align-center"><?php
+						echo wp_kses_post( _x( 'Exclusive access to the <em>Études</em> app for iOS and Android.', 'Feature for pricing level', 'twentytwentyfour' ) );
+					?></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:group -->
@@ -167,9 +167,9 @@
 				<div class="wp-block-buttons">
 					<!-- wp:button {"width":100,"className":"is-style-fill"} -->
 					<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill">
-						<a class="wp-block-button__link wp-element-button">
-							<?php echo esc_html_x( 'Subscribe', 'Call to action pricing level', 'twentytwentyfour' ); ?>
-						</a>
+						<a class="wp-block-button__link wp-element-button"><?php
+							echo esc_html_x( 'Subscribe', 'Call to action pricing level', 'twentytwentyfour' );
+						?></a>
 					</div>
 					<!-- /wp:button -->
 				</div>
@@ -181,16 +181,16 @@
 			<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--base-3);border-top-width:1px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--30)">
 				<!-- wp:heading {"textAlign":"center","level":4,"style":{"spacing":{"padding":{"top":"1px"}}},"fontSize":"medium"} -->
 				<h4 class="wp-block-heading has-text-align-center has-medium-font-size" style="padding-top:1px">
-					<em>
-						<?php echo esc_html_x( 'Expert', 'Title for Expert pricing level', 'twentytwentyfour' ); ?>
-					</em>
+					<em><?php
+						echo esc_html_x( 'Expert', 'Title for Expert pricing level', 'twentytwentyfour' );
+					?></em>
 				</h4>
 				<!-- /wp:heading -->
 
 				<!-- wp:heading {"textAlign":"center","level":5,"fontSize":"x-large"} -->
-				<h5 class="wp-block-heading has-text-align-center has-x-large-font-size">
-					<?php echo esc_html_x( '$28', 'Price for Expert pricing level', 'twentytwentyfour' ); ?>
-				</h5>
+				<h5 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php
+					echo esc_html_x( '$28', 'Price for Expert pricing level', 'twentytwentyfour' );
+				?></h5>
 				<!-- /wp:heading -->
 
 				<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
@@ -201,9 +201,9 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"align":"center"} -->
-					<p class="has-text-align-center">
-						<?php echo wp_kses_post( _x( 'Exclusive, unlimited access to <em>Études Articles</em>.', 'Feature for pricing level', 'twentytwentyfour' ) ); ?>
-					</p>
+					<p class="has-text-align-center"><?php
+						echo wp_kses_post( _x( 'Exclusive, unlimited access to <em>Études Articles</em>.', 'Feature for pricing level', 'twentytwentyfour' ) );
+					?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:separator {"backgroundColor":"base-3"} -->
@@ -211,9 +211,9 @@
 					<!-- /wp:separator -->
 
 					<!-- wp:paragraph {"align":"center"} -->
-					<p class="has-text-align-center">
-						<?php echo esc_html_x( 'Weekly print edition.', 'Feature for pricing level', 'twentytwentyfour' ); ?>
-					</p>
+					<p class="has-text-align-center"><?php
+						echo esc_html_x( 'Weekly print edition.', 'Feature for pricing level', 'twentytwentyfour' );
+					?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:separator {"backgroundColor":"base-3"} -->
@@ -221,9 +221,9 @@
 					<!-- /wp:separator -->
 
 					<!-- wp:paragraph {"align":"center"} -->
-					<p class="has-text-align-center">
-						<?php echo wp_kses_post( _x( 'Exclusive access to the <em>Études</em> app for iOS and Android', 'Feature for pricing level', 'twentytwentyfour' ) ); ?>
-					</p>
+					<p class="has-text-align-center"><?php
+						echo wp_kses_post( _x( 'Exclusive access to the <em>Études</em> app for iOS and Android', 'Feature for pricing level', 'twentytwentyfour' ) );
+					?></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:group -->
@@ -237,9 +237,9 @@
 				<div class="wp-block-buttons">
 					<!-- wp:button {"width":100,"className":"is-style-outline"} -->
 					<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-outline">
-						<a class="wp-block-button__link wp-element-button">
-							<?php echo esc_html_x( 'Subscribe', 'Call to action pricing level', 'twentytwentyfour' ); ?>
-						</a>
+						<a class="wp-block-button__link wp-element-button"><?php
+							echo esc_html_x( 'Subscribe', 'Call to action pricing level', 'twentytwentyfour' );
+						?></a>
 					</div>
 					<!-- /wp:button -->
 				</div>

--- a/patterns/pricing.php
+++ b/patterns/pricing.php
@@ -14,15 +14,11 @@
 		<!-- wp:group {"align":"wide","layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 		<div class="wp-block-group alignwide">
 			<!-- wp:heading {"textAlign":"center"} -->
-			<h2 class="wp-block-heading has-text-align-center"><?php
-				echo esc_html_x( 'Our Services', 'Heading for pricing pattern', 'twentytwentyfour' );
-			?></h2>
+			<h2 class="wp-block-heading has-text-align-center"><?php echo esc_html_x( 'Our Services', 'Heading for pricing pattern', 'twentytwentyfour' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"1.125rem"},"spacing":{"margin":{"top":"var:preset|spacing|10"}}}} -->
-			<p class="has-text-align-center" style="margin-top:var(--wp--preset--spacing--10);font-size:1.125rem"><?php
-				echo esc_html_x( 'We offer flexible options, which you can adapt to the different needs of each project.', 'Short blurb for pricing pattern', 'twentytwentyfour' );
-			?></p>
+			<p class="has-text-align-center" style="margin-top:var(--wp--preset--spacing--10);font-size:1.125rem"><?php echo esc_html_x( 'We offer flexible options, which you can adapt to the different needs of each project.', 'Short blurb for pricing pattern', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->
@@ -37,16 +33,12 @@
 			<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--base-3);border-top-width:1px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--30)">
 				<!-- wp:heading {"textAlign":"center","level":4,"style":{"spacing":{"padding":{"top":"1px"}}},"fontSize":"medium"} -->
 				<h4 class="wp-block-heading has-text-align-center has-medium-font-size" style="padding-top:1px">
-					<em><?php
-						echo esc_html_x( 'Free', 'Title for Free pricing level', 'twentytwentyfour' );
-					?></em>
+					<em><?php echo esc_html_x( 'Free', 'Title for Free pricing level', 'twentytwentyfour' ); ?></em>
 				</h4>
 				<!-- /wp:heading -->
 
 				<!-- wp:heading {"textAlign":"center","level":5,"fontSize":"x-large"} -->
-				<h5 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php
-					echo esc_html_x( '$0', 'Price for Free pricing level', 'twentytwentyfour' );
-				?></h5>
+				<h5 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html_x( '$0', 'Price for Free pricing level', 'twentytwentyfour' ); ?></h5>
 				<!-- /wp:heading -->
 
 				<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
@@ -57,9 +49,7 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"align":"center"} -->
-					<p class="has-text-align-center"><?php
-						echo wp_kses_post( _x( 'Access to 5 exclusive <em>Études Articles</em> per month.', 'Feature for pricing level', 'twentytwentyfour' ) );
-					?></p>
+					<p class="has-text-align-center"><?php echo wp_kses_post( _x( 'Access to 5 exclusive <em>Études Articles</em> per month.', 'Feature for pricing level', 'twentytwentyfour' ) ); ?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:separator {"backgroundColor":"base-3"} -->
@@ -68,9 +58,7 @@
 
 					<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
 					<p class="has-text-align-center has-contrast-2-color has-text-color has-link-color">
-						<s><?php
-							echo esc_html_x( 'Weekly print edition.', 'Feature for pricing level', 'twentytwentyfour' );
-						?></s>
+						<s><?php echo esc_html_x( 'Weekly print edition.', 'Feature for pricing level', 'twentytwentyfour' ); ?></s>
 					</p>
 					<!-- /wp:paragraph -->
 
@@ -80,9 +68,7 @@
 
 					<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
 					<p class="has-text-align-center has-contrast-2-color has-text-color has-link-color">
-						<s><?php
-							echo wp_kses_post( _x( 'Exclusive access to the <em>Études</em> app for iOS and Android.', 'Feature for pricing level', 'twentytwentyfour' ) );
-						?></s>
+						<s><?php echo wp_kses_post( _x( 'Exclusive access to the <em>Études</em> app for iOS and Android.', 'Feature for pricing level', 'twentytwentyfour' ) ); ?></s>
 					</p>
 					<!-- /wp:paragraph -->
 				</div>
@@ -97,9 +83,7 @@
 				<div class="wp-block-buttons">
 					<!-- wp:button {"width":100,"className":"is-style-outline"} -->
 					<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-outline">
-						<a class="wp-block-button__link wp-element-button"><?php
-							echo esc_html_x( 'Subscribe', 'Call to action pricing level', 'twentytwentyfour' );
-						?></a>
+						<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Subscribe', 'Call to action pricing level', 'twentytwentyfour' ); ?></a>
 					</div>
 					<!-- /wp:button -->
 				</div>
@@ -111,16 +95,12 @@
 			<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--contrast);border-top-width:2px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--30)">
 				<!-- wp:heading {"textAlign":"center","level":4} -->
 				<h4 class="wp-block-heading has-text-align-center">
-					<em><?php
-						echo esc_html_x( 'Connoisseur', 'Title for Connoisseur pricing level', 'twentytwentyfour' );
-					?></em>
+					<em><?php echo esc_html_x( 'Connoisseur', 'Title for Connoisseur pricing level', 'twentytwentyfour' ); ?></em>
 				</h4>
 				<!-- /wp:heading -->
 
 				<!-- wp:heading {"textAlign":"center","level":5,"fontSize":"x-large"} -->
-				<h5 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php
-					echo esc_html_x( '$12', 'Price for Connoisseur pricing level', 'twentytwentyfour' );
-				?></h5>
+				<h5 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html_x( '$12', 'Price for Connoisseur pricing level', 'twentytwentyfour' ); ?></h5>
 				<!-- /wp:heading -->
 
 				<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
@@ -131,9 +111,7 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"align":"center"} -->
-					<p class="has-text-align-center"><?php
-						echo wp_kses_post( _x( 'Access to 20 exclusive <em>Études Articles</em> per month.', 'Feature for pricing level', 'twentytwentyfour' ) );
-					?></p>
+					<p class="has-text-align-center"><?php echo wp_kses_post( _x( 'Access to 20 exclusive <em>Études Articles</em> per month.', 'Feature for pricing level', 'twentytwentyfour' ) ); ?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:separator {"backgroundColor":"base-3"} -->
@@ -141,9 +119,7 @@
 					<!-- /wp:separator -->
 
 					<!-- wp:paragraph {"align":"center"} -->
-					<p class="has-text-align-center"><?php
-						echo esc_html_x( 'Weekly print edition.', 'Feature for pricing level', 'twentytwentyfour' );
-					?></p>
+					<p class="has-text-align-center"><?php echo esc_html_x( 'Weekly print edition.', 'Feature for pricing level', 'twentytwentyfour' ); ?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:separator {"backgroundColor":"base-3"} -->
@@ -151,9 +127,7 @@
 					<!-- /wp:separator -->
 
 					<!-- wp:paragraph {"align":"center"} -->
-					<p class="has-text-align-center"><?php
-						echo wp_kses_post( _x( 'Exclusive access to the <em>Études</em> app for iOS and Android.', 'Feature for pricing level', 'twentytwentyfour' ) );
-					?></p>
+					<p class="has-text-align-center"><?php echo wp_kses_post( _x( 'Exclusive access to the <em>Études</em> app for iOS and Android.', 'Feature for pricing level', 'twentytwentyfour' ) ); ?></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:group -->
@@ -167,9 +141,7 @@
 				<div class="wp-block-buttons">
 					<!-- wp:button {"width":100,"className":"is-style-fill"} -->
 					<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill">
-						<a class="wp-block-button__link wp-element-button"><?php
-							echo esc_html_x( 'Subscribe', 'Call to action pricing level', 'twentytwentyfour' );
-						?></a>
+						<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Subscribe', 'Call to action pricing level', 'twentytwentyfour' ); ?></a>
 					</div>
 					<!-- /wp:button -->
 				</div>
@@ -181,16 +153,12 @@
 			<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--base-3);border-top-width:1px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--30)">
 				<!-- wp:heading {"textAlign":"center","level":4,"style":{"spacing":{"padding":{"top":"1px"}}},"fontSize":"medium"} -->
 				<h4 class="wp-block-heading has-text-align-center has-medium-font-size" style="padding-top:1px">
-					<em><?php
-						echo esc_html_x( 'Expert', 'Title for Expert pricing level', 'twentytwentyfour' );
-					?></em>
+					<em><?php echo esc_html_x( 'Expert', 'Title for Expert pricing level', 'twentytwentyfour' ); ?></em>
 				</h4>
 				<!-- /wp:heading -->
 
 				<!-- wp:heading {"textAlign":"center","level":5,"fontSize":"x-large"} -->
-				<h5 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php
-					echo esc_html_x( '$28', 'Price for Expert pricing level', 'twentytwentyfour' );
-				?></h5>
+				<h5 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html_x( '$28', 'Price for Expert pricing level', 'twentytwentyfour' ); ?></h5>
 				<!-- /wp:heading -->
 
 				<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
@@ -201,9 +169,7 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"align":"center"} -->
-					<p class="has-text-align-center"><?php
-						echo wp_kses_post( _x( 'Exclusive, unlimited access to <em>Études Articles</em>.', 'Feature for pricing level', 'twentytwentyfour' ) );
-					?></p>
+					<p class="has-text-align-center"><?php echo wp_kses_post( _x( 'Exclusive, unlimited access to <em>Études Articles</em>.', 'Feature for pricing level', 'twentytwentyfour' ) ); ?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:separator {"backgroundColor":"base-3"} -->
@@ -211,9 +177,7 @@
 					<!-- /wp:separator -->
 
 					<!-- wp:paragraph {"align":"center"} -->
-					<p class="has-text-align-center"><?php
-						echo esc_html_x( 'Weekly print edition.', 'Feature for pricing level', 'twentytwentyfour' );
-					?></p>
+					<p class="has-text-align-center"><?php echo esc_html_x( 'Weekly print edition.', 'Feature for pricing level', 'twentytwentyfour' ); ?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:separator {"backgroundColor":"base-3"} -->
@@ -221,9 +185,7 @@
 					<!-- /wp:separator -->
 
 					<!-- wp:paragraph {"align":"center"} -->
-					<p class="has-text-align-center"><?php
-						echo wp_kses_post( _x( 'Exclusive access to the <em>Études</em> app for iOS and Android', 'Feature for pricing level', 'twentytwentyfour' ) );
-					?></p>
+					<p class="has-text-align-center"><?php echo wp_kses_post( _x( 'Exclusive access to the <em>Études</em> app for iOS and Android', 'Feature for pricing level', 'twentytwentyfour' ) ); ?></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:group -->
@@ -237,9 +199,7 @@
 				<div class="wp-block-buttons">
 					<!-- wp:button {"width":100,"className":"is-style-outline"} -->
 					<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-outline">
-						<a class="wp-block-button__link wp-element-button"><?php
-							echo esc_html_x( 'Subscribe', 'Call to action pricing level', 'twentytwentyfour' );
-						?></a>
+						<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Subscribe', 'Call to action pricing level', 'twentytwentyfour' ); ?></a>
 					</div>
 					<!-- /wp:button -->
 				</div>

--- a/patterns/project-description.php
+++ b/patterns/project-description.php
@@ -13,9 +13,9 @@
 		<!-- wp:column {"width":"40%"} -->
 		<div class="wp-block-column" style="flex-basis:40%">
 			<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fixed","flexSize":"50%"}}} -->
-			<p>
-				<?php echo esc_html_x( 'Art Gallery — Overview', 'Project Name or Title', 'twentytwentyfour' ); ?>
-			</p>
+			<p><?php
+				echo esc_html_x( 'Art Gallery — Overview', 'Project Name or Title', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -24,9 +24,9 @@
 		<div class="wp-block-column" style="flex-basis:60%">
 
 			<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large","fontFamily":"heading"} -->
-			<p class="has-heading-font-family has-x-large-font-size" style="line-height:1.2">
-				<?php echo esc_html_x( 'This transformative project seeks to enhance the gallery\'s infrastructure, accessibility, and exhibition spaces while preserving its rich cultural heritage.', 'A heading type project description.', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-heading-font-family has-x-large-font-size" style="line-height:1.2"><?php
+				echo esc_html_x( 'This transformative project seeks to enhance the gallery\'s infrastructure, accessibility, and exhibition spaces while preserving its rich cultural heritage.', 'A heading type project description.', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 
 		</div>

--- a/patterns/project-description.php
+++ b/patterns/project-description.php
@@ -13,9 +13,7 @@
 		<!-- wp:column {"width":"40%"} -->
 		<div class="wp-block-column" style="flex-basis:40%">
 			<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fixed","flexSize":"50%"}}} -->
-			<p><?php
-				echo esc_html_x( 'Art Gallery — Overview', 'Project Name or Title', 'twentytwentyfour' );
-			?></p>
+			<p><?php echo esc_html_x( 'Art Gallery — Overview', 'Project Name or Title', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -24,9 +22,7 @@
 		<div class="wp-block-column" style="flex-basis:60%">
 
 			<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large","fontFamily":"heading"} -->
-			<p class="has-heading-font-family has-x-large-font-size" style="line-height:1.2"><?php
-				echo esc_html_x( 'This transformative project seeks to enhance the gallery\'s infrastructure, accessibility, and exhibition spaces while preserving its rich cultural heritage.', 'A heading type project description.', 'twentytwentyfour' );
-			?></p>
+			<p class="has-heading-font-family has-x-large-font-size" style="line-height:1.2"><?php echo esc_html_x( 'This transformative project seeks to enhance the gallery\'s infrastructure, accessibility, and exhibition spaces while preserving its rich cultural heritage.', 'A heading type project description.', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 
 		</div>

--- a/patterns/project-details.php
+++ b/patterns/project-details.php
@@ -14,9 +14,7 @@
 		<!-- wp:column {"width":"40%","layout":{"type":"constrained","contentSize":"260px","justifyContent":"left"}} -->
 		<div class="wp-block-column" style="flex-basis:40%">
 			<!-- wp:paragraph -->
-			<p><?php
-				echo esc_html_x( 'The revitalized art gallery is set to redefine cultural landscape.', 'Title text for the feature area', 'twentytwentyfour' );
-			?></p>
+			<p><?php echo esc_html_x( 'The revitalized art gallery is set to redefine cultural landscape.', 'Title text for the feature area', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -25,9 +23,7 @@
 		<div class="wp-block-column" style="flex-basis:60%">
 
 			<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large","fontFamily":"heading"} -->
-			<p class="has-heading-font-family has-x-large-font-size" style="line-height:1.2"><?php
-				echo esc_html_x( 'With meticulous attention to detail and a commitment to excellence, we create spaces that inspire, elevate, and enrich the lives of those who inhabit them.', 'Descriptive title for the feature area', 'twentytwentyfour' );
-			?></p>
+			<p class="has-heading-font-family has-x-large-font-size" style="line-height:1.2"><?php echo esc_html_x( 'With meticulous attention to detail and a commitment to excellence, we create spaces that inspire, elevate, and enrich the lives of those who inhabit them.', 'Descriptive title for the feature area', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
@@ -35,9 +31,7 @@
 				<!-- wp:column -->
 				<div class="wp-block-column">
 					<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fill","flexSize":null}}} -->
-					<p><?php
-						echo esc_html_x( 'The revitalized Art Gallery is set to redefine the cultural landscape of Toronto, serving as a nexus of artistic expression, community engagement, and architectural marvel. The expansion and renovation project pay homage to the Art Gallery\'s rich history while embracing the future, ensuring that the gallery remains a beacon of inspiration.', 'Descriptive text for the feature area', 'twentytwentyfour' );
-					?></p>
+					<p><?php echo esc_html_x( 'The revitalized Art Gallery is set to redefine the cultural landscape of Toronto, serving as a nexus of artistic expression, community engagement, and architectural marvel. The expansion and renovation project pay homage to the Art Gallery\'s rich history while embracing the future, ensuring that the gallery remains a beacon of inspiration.', 'Descriptive text for the feature area', 'twentytwentyfour' ); ?></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:column -->
@@ -45,9 +39,7 @@
 				<!-- wp:column -->
 				<div class="wp-block-column">
 					<!-- wp:paragraph -->
-					<p><?php
-						echo esc_html_x( 'The revitalized Art Gallery is set to redefine the cultural landscape of Toronto, serving as a nexus of artistic expression, community engagement, and architectural marvel. The expansion and renovation project pay homage to the Art Gallery\'s rich history while embracing the future, ensuring that the gallery remains a beacon of inspiration.', 'Descriptive text for the feature area', 'twentytwentyfour' );
-					?></p>
+					<p><?php echo esc_html_x( 'The revitalized Art Gallery is set to redefine the cultural landscape of Toronto, serving as a nexus of artistic expression, community engagement, and architectural marvel. The expansion and renovation project pay homage to the Art Gallery\'s rich history while embracing the future, ensuring that the gallery remains a beacon of inspiration.', 'Descriptive text for the feature area', 'twentytwentyfour' ); ?></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:column -->

--- a/patterns/project-details.php
+++ b/patterns/project-details.php
@@ -14,9 +14,9 @@
 		<!-- wp:column {"width":"40%","layout":{"type":"constrained","contentSize":"260px","justifyContent":"left"}} -->
 		<div class="wp-block-column" style="flex-basis:40%">
 			<!-- wp:paragraph -->
-			<p>
-				<?php echo esc_html_x( 'The revitalized art gallery is set to redefine cultural landscape.', 'Title text for the feature area', 'twentytwentyfour' ); ?>
-			</p>
+			<p><?php
+				echo esc_html_x( 'The revitalized art gallery is set to redefine cultural landscape.', 'Title text for the feature area', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -25,9 +25,9 @@
 		<div class="wp-block-column" style="flex-basis:60%">
 
 			<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large","fontFamily":"heading"} -->
-			<p class="has-heading-font-family has-x-large-font-size" style="line-height:1.2">
-				<?php echo esc_html_x( 'With meticulous attention to detail and a commitment to excellence, we create spaces that inspire, elevate, and enrich the lives of those who inhabit them.', 'Descriptive title for the feature area', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-heading-font-family has-x-large-font-size" style="line-height:1.2"><?php
+				echo esc_html_x( 'With meticulous attention to detail and a commitment to excellence, we create spaces that inspire, elevate, and enrich the lives of those who inhabit them.', 'Descriptive title for the feature area', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
@@ -35,9 +35,9 @@
 				<!-- wp:column -->
 				<div class="wp-block-column">
 					<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fill","flexSize":null}}} -->
-					<p>
-						<?php echo esc_html_x( 'The revitalized Art Gallery is set to redefine the cultural landscape of Toronto, serving as a nexus of artistic expression, community engagement, and architectural marvel. The expansion and renovation project pay homage to the Art Gallery\'s rich history while embracing the future, ensuring that the gallery remains a beacon of inspiration.', 'Descriptive text for the feature area', 'twentytwentyfour' ); ?>
-					</p>
+					<p><?php
+						echo esc_html_x( 'The revitalized Art Gallery is set to redefine the cultural landscape of Toronto, serving as a nexus of artistic expression, community engagement, and architectural marvel. The expansion and renovation project pay homage to the Art Gallery\'s rich history while embracing the future, ensuring that the gallery remains a beacon of inspiration.', 'Descriptive text for the feature area', 'twentytwentyfour' );
+					?></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:column -->
@@ -45,9 +45,9 @@
 				<!-- wp:column -->
 				<div class="wp-block-column">
 					<!-- wp:paragraph -->
-					<p>
-						<?php echo esc_html_x( 'The revitalized Art Gallery is set to redefine the cultural landscape of Toronto, serving as a nexus of artistic expression, community engagement, and architectural marvel. The expansion and renovation project pay homage to the Art Gallery\'s rich history while embracing the future, ensuring that the gallery remains a beacon of inspiration.', 'Descriptive text for the feature area', 'twentytwentyfour' ); ?>
-					</p>
+					<p><?php
+						echo esc_html_x( 'The revitalized Art Gallery is set to redefine the cultural landscape of Toronto, serving as a nexus of artistic expression, community engagement, and architectural marvel. The expansion and renovation project pay homage to the Art Gallery\'s rich history while embracing the future, ensuring that the gallery remains a beacon of inspiration.', 'Descriptive text for the feature area', 'twentytwentyfour' );
+					?></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:column -->

--- a/patterns/project-layout.php
+++ b/patterns/project-layout.php
@@ -22,9 +22,9 @@
 				<!-- /wp:image -->
 
 				<!-- wp:paragraph {"fontSize":"medium"} -->
-				<p class="has-medium-font-size">
-					<?php echo esc_html_x( '1. Through Études, we aspire to redefine architectural boundaries and usher in a new era of design excellence that leaves an indelible mark on the built environment.', 'give the user a clear understanding of what the photo talks about', 'twentytwentyfour' ); ?>
-				</p>
+				<p class="has-medium-font-size"><?php
+					echo esc_html_x( '1. Through Études, we aspire to redefine architectural boundaries and usher in a new era of design excellence that leaves an indelible mark on the built environment.', 'give the user a clear understanding of what the photo talks about', 'twentytwentyfour' );
+				?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
@@ -36,9 +36,9 @@
 			<!-- wp:group {"layout":{"type":"constrained"}} -->
 			<div class="wp-block-group">
 				<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2","fontStyle":"normal","fontWeight":"500"}},"fontSize":"large"} -->
-				<p class="has-large-font-size" style="font-style:normal;font-weight:500;line-height:1.2">
-					<?php echo esc_html_x( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers. With a commitment to innovation and sustainability, Études is the bridge that transforms architectural dreams into remarkable built realities.', 'an explanation of the objective of the project', 'twentytwentyfour' ); ?>
-				</p>
+				<p class="has-large-font-size" style="font-style:normal;font-weight:500;line-height:1.2"><?php
+					echo esc_html_x( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers. With a commitment to innovation and sustainability, Études is the bridge that transforms architectural dreams into remarkable built realities.', 'an explanation of the objective of the project', 'twentytwentyfour' );
+				?></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:spacer {"height":"var:preset|spacing|40","style":{"layout":{}}} -->
@@ -49,9 +49,9 @@
 				<!-- wp:group {"layout":{"type":"default"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"fontSize":"medium"} -->
-					<p class="has-medium-font-size">
-						<?php echo esc_html_x( '2. Case studies that celebrate the artistry can fuel curiosity and ignite inspiration.', 'An Overview of the project', 'twentytwentyfour' ); ?>
-					</p>
+					<p class="has-medium-font-size"><?php
+						echo esc_html_x( '2. Case studies that celebrate the artistry can fuel curiosity and ignite inspiration.', 'An Overview of the project', 'twentytwentyfour' );
+					?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:image {"aspectRatio":"9/16","scale":"cover","sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->

--- a/patterns/project-layout.php
+++ b/patterns/project-layout.php
@@ -22,9 +22,7 @@
 				<!-- /wp:image -->
 
 				<!-- wp:paragraph {"fontSize":"medium"} -->
-				<p class="has-medium-font-size"><?php
-					echo esc_html_x( '1. Through Études, we aspire to redefine architectural boundaries and usher in a new era of design excellence that leaves an indelible mark on the built environment.', 'give the user a clear understanding of what the photo talks about', 'twentytwentyfour' );
-				?></p>
+				<p class="has-medium-font-size"><?php echo esc_html_x( '1. Through Études, we aspire to redefine architectural boundaries and usher in a new era of design excellence that leaves an indelible mark on the built environment.', 'give the user a clear understanding of what the photo talks about', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
@@ -36,9 +34,7 @@
 			<!-- wp:group {"layout":{"type":"constrained"}} -->
 			<div class="wp-block-group">
 				<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2","fontStyle":"normal","fontWeight":"500"}},"fontSize":"large"} -->
-				<p class="has-large-font-size" style="font-style:normal;font-weight:500;line-height:1.2"><?php
-					echo esc_html_x( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers. With a commitment to innovation and sustainability, Études is the bridge that transforms architectural dreams into remarkable built realities.', 'an explanation of the objective of the project', 'twentytwentyfour' );
-				?></p>
+				<p class="has-large-font-size" style="font-style:normal;font-weight:500;line-height:1.2"><?php echo esc_html_x( 'Our comprehensive suite of professional services caters to a diverse clientele, ranging from homeowners to commercial developers. With a commitment to innovation and sustainability, Études is the bridge that transforms architectural dreams into remarkable built realities.', 'an explanation of the objective of the project', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:spacer {"height":"var:preset|spacing|40","style":{"layout":{}}} -->
@@ -49,9 +45,7 @@
 				<!-- wp:group {"layout":{"type":"default"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"fontSize":"medium"} -->
-					<p class="has-medium-font-size"><?php
-						echo esc_html_x( '2. Case studies that celebrate the artistry can fuel curiosity and ignite inspiration.', 'An Overview of the project', 'twentytwentyfour' );
-					?></p>
+					<p class="has-medium-font-size"><?php echo esc_html_x( '2. Case studies that celebrate the artistry can fuel curiosity and ignite inspiration.', 'An Overview of the project', 'twentytwentyfour' ); ?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:image {"aspectRatio":"9/16","scale":"cover","sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->

--- a/patterns/services-cta.php
+++ b/patterns/services-cta.php
@@ -24,24 +24,24 @@
 		<!-- wp:column {"width":"40%"} -->
 		<div class="wp-block-column" style="flex-basis:40%">
 			<!-- wp:heading -->
-			<h2 class="wp-block-heading">
-				<?php echo esc_html_x( 'Guiding your business through the project', 'Heading of The Service Call to Action', 'twentytwentyfour' ); ?>
-			</h2>
+			<h2 class="wp-block-heading"><?php
+				echo esc_html_x( 'Guiding your business through the project', 'Heading of The Service Call to Action', 'twentytwentyfour' );
+			?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph -->
-			<p>
-				<?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études—the catalyst for architectural transformations that enrich the world around us.', 'Service Description of Call to Action', 'twentytwentyfour' ); ?>
-			</p>
+			<p><?php
+				echo esc_html_x( 'Experience the fusion of imagination and expertise with Études—the catalyst for architectural transformations that enrich the world around us.', 'Service Description of Call to Action', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:buttons -->
 			<div class="wp-block-buttons">
 				<!-- wp:button -->
 				<div class="wp-block-button">
-					<a class="wp-block-button__link wp-element-button">
-						<?php echo esc_html_x( 'Our services', 'Call to Action Button Text', 'twentytwentyfour' ); ?>
-					</a>
+					<a class="wp-block-button__link wp-element-button"><?php
+						echo esc_html_x( 'Our services', 'Call to Action Button Text', 'twentytwentyfour' );
+					?></a>
 				</div>
 				<!-- /wp:button -->
 			</div>

--- a/patterns/services-cta.php
+++ b/patterns/services-cta.php
@@ -24,24 +24,18 @@
 		<!-- wp:column {"width":"40%"} -->
 		<div class="wp-block-column" style="flex-basis:40%">
 			<!-- wp:heading -->
-			<h2 class="wp-block-heading"><?php
-				echo esc_html_x( 'Guiding your business through the project', 'Heading of The Service Call to Action', 'twentytwentyfour' );
-			?></h2>
+			<h2 class="wp-block-heading"><?php echo esc_html_x( 'Guiding your business through the project', 'Heading of The Service Call to Action', 'twentytwentyfour' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph -->
-			<p><?php
-				echo esc_html_x( 'Experience the fusion of imagination and expertise with Études—the catalyst for architectural transformations that enrich the world around us.', 'Service Description of Call to Action', 'twentytwentyfour' );
-			?></p>
+			<p><?php echo esc_html_x( 'Experience the fusion of imagination and expertise with Études—the catalyst for architectural transformations that enrich the world around us.', 'Service Description of Call to Action', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:buttons -->
 			<div class="wp-block-buttons">
 				<!-- wp:button -->
 				<div class="wp-block-button">
-					<a class="wp-block-button__link wp-element-button"><?php
-						echo esc_html_x( 'Our services', 'Call to Action Button Text', 'twentytwentyfour' );
-					?></a>
+					<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Our services', 'Call to Action Button Text', 'twentytwentyfour' ); ?></a>
 				</div>
 				<!-- /wp:button -->
 			</div>

--- a/patterns/team.php
+++ b/patterns/team.php
@@ -12,15 +12,15 @@
 	<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 	<div class="wp-block-group">
 		<!-- wp:heading {"textAlign":"center","fontSize":"xx-large"} -->
-		<h2 class="wp-block-heading has-text-align-center has-xx-large-font-size">
-			<?php echo esc_html_x( 'Meet our team', 'Heading of Team Pattern', 'twentytwentyfour' ); ?>
-		</h2>
+		<h2 class="wp-block-heading has-text-align-center has-xx-large-font-size"><?php
+			echo esc_html_x( 'Meet our team', 'Heading of Team Pattern', 'twentytwentyfour' );
+		?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center">
-			<?php echo esc_html_x( 'Our comprehensive suite of professionals caters to a diverse team, ranging from seasoned architects to renowned engineers.', 'Description of Team Pattern', 'twentytwentyfour' ); ?>
-		</p>
+		<p class="has-text-align-center"><?php
+			echo esc_html_x( 'Our comprehensive suite of professionals caters to a diverse team, ranging from seasoned architects to renowned engineers.', 'Description of Team Pattern', 'twentytwentyfour' );
+		?></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->
@@ -44,44 +44,16 @@
 			<div class="wp-block-group">
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 				<p class="has-text-align-center has-small-font-size">
-					<strong>
-						<?php echo esc_html_x( 'Francesca Piovani', 'Team Member Name', 'twentytwentyfour' ); ?>
-					</strong>
+					<strong><?php
+						echo esc_html_x( 'Francesca Piovani', 'Team Member Name', 'twentytwentyfour' );
+					?></strong>
 				</p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-				<p class="has-text-align-center has-small-font-size">
-					<?php echo esc_html_x( 'Founder, CEO & Architect', 'Team Member Designation', 'twentytwentyfour' ); ?>
-				</p>
-				<!-- /wp:paragraph -->
-			</div>
-			<!-- /wp:group -->
-		</div>
-		<!-- /wp:column -->
-
-		<!-- wp:column {"layout":{"type":"default"}} -->
-		<div class="wp-block-column">
-			<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-rounded"} -->
-			<figure class="wp-block-image size-full is-style-rounded">
-				<img alt="" style="aspect-ratio:1;object-fit:cover" />
-			</figure>
-			<!-- /wp:image -->
-
-			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|0"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center","flexWrap":"nowrap"}} -->
-			<div class="wp-block-group">
-				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-				<p class="has-text-align-center has-small-font-size">
-					<strong>
-						<?php echo esc_html_x( 'Rhye Moore', 'Team Member Name', 'twentytwentyfour' ); ?>
-					</strong>
-				</p>
-				<!-- /wp:paragraph -->
-
-				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-				<p class="has-text-align-center has-small-font-size">
-					<?php echo esc_html_x( 'Engineering Manager', 'Team Member Designation', 'twentytwentyfour' ); ?>
-				</p>
+				<p class="has-text-align-center has-small-font-size"><?php
+					echo esc_html_x( 'Founder, CEO & Architect', 'Team Member Designation', 'twentytwentyfour' );
+				?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
@@ -100,16 +72,44 @@
 			<div class="wp-block-group">
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 				<p class="has-text-align-center has-small-font-size">
-					<strong>
-						<?php echo esc_html_x( 'Helga Steiner', 'Team Member Name', 'twentytwentyfour' ); ?>
-					</strong>
+					<strong><?php
+						echo esc_html_x( 'Rhye Moore', 'Team Member Name', 'twentytwentyfour' );
+					?></strong>
 				</p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+				<p class="has-text-align-center has-small-font-size"><?php
+					echo esc_html_x( 'Engineering Manager', 'Team Member Designation', 'twentytwentyfour' );
+				?></p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"layout":{"type":"default"}} -->
+		<div class="wp-block-column">
+			<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-rounded"} -->
+			<figure class="wp-block-image size-full is-style-rounded">
+				<img alt="" style="aspect-ratio:1;object-fit:cover" />
+			</figure>
+			<!-- /wp:image -->
+
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|0"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center","flexWrap":"nowrap"}} -->
+			<div class="wp-block-group">
+				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 				<p class="has-text-align-center has-small-font-size">
-					<?php echo esc_html_x( 'Architect', 'Team Member Designation', 'twentytwentyfour' ); ?>
+					<strong><?php
+						echo esc_html_x( 'Helga Steiner', 'Team Member Name', 'twentytwentyfour' );
+					?></strong>
 				</p>
+				<!-- /wp:paragraph -->
+
+				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+				<p class="has-text-align-center has-small-font-size"><?php
+					echo esc_html_x( 'Architect', 'Team Member Designation', 'twentytwentyfour' );
+				?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
@@ -128,16 +128,16 @@
 			<div class="wp-block-group">
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 				<p class="has-text-align-center has-small-font-size">
-					<strong>
-						<?php echo esc_html_x( 'Ivan Lawrence', 'Team Member Name', 'twentytwentyfour' ); ?>
-					</strong>
+					<strong><?php
+						echo esc_html_x( 'Ivan Lawrence', 'Team Member Name', 'twentytwentyfour' );
+					?></strong>
 				</p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-				<p class="has-text-align-center has-small-font-size">
-					<?php echo esc_html_x( 'Project Manager', 'Team Member Designation', 'twentytwentyfour' ); ?>
-				</p>
+				<p class="has-text-align-center has-small-font-size"><?php
+					echo esc_html_x( 'Project Manager', 'Team Member Designation', 'twentytwentyfour' );
+				?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->

--- a/patterns/team.php
+++ b/patterns/team.php
@@ -12,15 +12,11 @@
 	<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 	<div class="wp-block-group">
 		<!-- wp:heading {"textAlign":"center","fontSize":"xx-large"} -->
-		<h2 class="wp-block-heading has-text-align-center has-xx-large-font-size"><?php
-			echo esc_html_x( 'Meet our team', 'Heading of Team Pattern', 'twentytwentyfour' );
-		?></h2>
+		<h2 class="wp-block-heading has-text-align-center has-xx-large-font-size"><?php echo esc_html_x( 'Meet our team', 'Heading of Team Pattern', 'twentytwentyfour' ); ?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center"><?php
-			echo esc_html_x( 'Our comprehensive suite of professionals caters to a diverse team, ranging from seasoned architects to renowned engineers.', 'Description of Team Pattern', 'twentytwentyfour' );
-		?></p>
+		<p class="has-text-align-center"><?php echo esc_html_x( 'Our comprehensive suite of professionals caters to a diverse team, ranging from seasoned architects to renowned engineers.', 'Description of Team Pattern', 'twentytwentyfour' ); ?></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->
@@ -44,16 +40,12 @@
 			<div class="wp-block-group">
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 				<p class="has-text-align-center has-small-font-size">
-					<strong><?php
-						echo esc_html_x( 'Francesca Piovani', 'Team Member Name', 'twentytwentyfour' );
-					?></strong>
+					<strong><?php echo esc_html_x( 'Francesca Piovani', 'Team Member Name', 'twentytwentyfour' ); ?></strong>
 				</p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-				<p class="has-text-align-center has-small-font-size"><?php
-					echo esc_html_x( 'Founder, CEO & Architect', 'Team Member Designation', 'twentytwentyfour' );
-				?></p>
+				<p class="has-text-align-center has-small-font-size"><?php echo esc_html_x( 'Founder, CEO & Architect', 'Team Member Designation', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
@@ -72,16 +64,12 @@
 			<div class="wp-block-group">
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 				<p class="has-text-align-center has-small-font-size">
-					<strong><?php
-						echo esc_html_x( 'Rhye Moore', 'Team Member Name', 'twentytwentyfour' );
-					?></strong>
+					<strong><?php echo esc_html_x( 'Rhye Moore', 'Team Member Name', 'twentytwentyfour' ); ?></strong>
 				</p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-				<p class="has-text-align-center has-small-font-size"><?php
-					echo esc_html_x( 'Engineering Manager', 'Team Member Designation', 'twentytwentyfour' );
-				?></p>
+				<p class="has-text-align-center has-small-font-size"><?php echo esc_html_x( 'Engineering Manager', 'Team Member Designation', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
@@ -100,16 +88,12 @@
 			<div class="wp-block-group">
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 				<p class="has-text-align-center has-small-font-size">
-					<strong><?php
-						echo esc_html_x( 'Helga Steiner', 'Team Member Name', 'twentytwentyfour' );
-					?></strong>
+					<strong><?php echo esc_html_x( 'Helga Steiner', 'Team Member Name', 'twentytwentyfour' ); ?></strong>
 				</p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-				<p class="has-text-align-center has-small-font-size"><?php
-					echo esc_html_x( 'Architect', 'Team Member Designation', 'twentytwentyfour' );
-				?></p>
+				<p class="has-text-align-center has-small-font-size"><?php echo esc_html_x( 'Architect', 'Team Member Designation', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
@@ -128,16 +112,12 @@
 			<div class="wp-block-group">
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 				<p class="has-text-align-center has-small-font-size">
-					<strong><?php
-						echo esc_html_x( 'Ivan Lawrence', 'Team Member Name', 'twentytwentyfour' );
-					?></strong>
+					<strong><?php echo esc_html_x( 'Ivan Lawrence', 'Team Member Name', 'twentytwentyfour' ); ?></strong>
 				</p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-				<p class="has-text-align-center has-small-font-size"><?php
-					echo esc_html_x( 'Project Manager', 'Team Member Designation', 'twentytwentyfour' );
-				?></p>
+				<p class="has-text-align-center has-small-font-size"><?php echo esc_html_x( 'Project Manager', 'Team Member Designation', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->

--- a/patterns/template-index-portfolio.php
+++ b/patterns/template-index-portfolio.php
@@ -12,9 +12,7 @@
 <!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignfull">
 	<!-- wp:heading {"level":1,"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50"}}}} -->
-	<h1 class="wp-block-heading alignwide" style="padding-top:var(--wp--preset--spacing--50)"><?php
-		esc_html_e( 'Posts', 'twentytwentyfour' );
-	?></h1>
+	<h1 class="wp-block-heading alignwide" style="padding-top:var(--wp--preset--spacing--50)"><?php esc_html_e( 'Posts', 'twentytwentyfour' ); ?></h1>
 	<!-- /wp:heading -->
 
 	<!-- wp:pattern {"slug":"twentytwentyfour/offset-grid-image-posts"} /-->

--- a/patterns/template-index-portfolio.php
+++ b/patterns/template-index-portfolio.php
@@ -12,9 +12,9 @@
 <!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignfull">
 	<!-- wp:heading {"level":1,"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50"}}}} -->
-	<h1 class="wp-block-heading alignwide" style="padding-top:var(--wp--preset--spacing--50)">
-		<?php esc_html_e( 'Posts', 'twentytwentyfour' ); ?>
-	</h1>
+	<h1 class="wp-block-heading alignwide" style="padding-top:var(--wp--preset--spacing--50)"><?php
+		esc_html_e( 'Posts', 'twentytwentyfour' );
+	?></h1>
 	<!-- /wp:heading -->
 
 	<!-- wp:pattern {"slug":"twentytwentyfour/offset-grid-image-posts"} /-->

--- a/patterns/template-index-writer.php
+++ b/patterns/template-index-writer.php
@@ -13,9 +13,7 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0","margin":{"top":"0"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:0">
 	<!-- wp:heading {"level":1,"style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"var:preset|spacing|50"}}}} -->
-	<h1 class="wp-block-heading" style="padding-top:var(--wp--preset--spacing--50);line-height:1"><?php
-		esc_html_e( 'Watch, Read, Listen', 'twentytwentyfour' );
-	?></h1>
+	<h1 class="wp-block-heading" style="padding-top:var(--wp--preset--spacing--50);line-height:1"><?php esc_html_e( 'Watch, Read, Listen', 'twentytwentyfour' ); ?></h1>
 	<!-- /wp:heading -->
 
 	<!-- wp:pattern {"slug":"twentytwentyfour/posts-one-column"} /-->

--- a/patterns/template-index-writer.php
+++ b/patterns/template-index-writer.php
@@ -13,9 +13,9 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0","margin":{"top":"0"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:0">
 	<!-- wp:heading {"level":1,"style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"var:preset|spacing|50"}}}} -->
-	<h1 class="wp-block-heading" style="padding-top:var(--wp--preset--spacing--50);line-height:1">
-		<?php esc_html_e( 'Watch, Read, Listen', 'twentytwentyfour' ); ?>
-	</h1>
+	<h1 class="wp-block-heading" style="padding-top:var(--wp--preset--spacing--50);line-height:1"><?php
+		esc_html_e( 'Watch, Read, Listen', 'twentytwentyfour' );
+	?></h1>
 	<!-- /wp:heading -->
 
 	<!-- wp:pattern {"slug":"twentytwentyfour/posts-one-column"} /-->

--- a/patterns/testimonial-centered.php
+++ b/patterns/testimonial-centered.php
@@ -14,9 +14,7 @@
 	<div class="wp-block-group">
 		<!-- wp:paragraph {"align":"center","style":{"typography":{"lineHeight":"1.2"}},"textColor":"base","fontSize":"x-large","fontFamily":"heading"} -->
 		<p class="has-text-align-center has-base-color has-text-color has-heading-font-family has-x-large-font-size" style="line-height:1.2">
-			<em><?php
-				echo esc_html_x( '“Études has saved us thousands of hours of work and has unlocked insights we never thought possible.”', 'Testimonial Text or Review Text Got From the Person', 'twentytwentyfour' );
-			?></em>
+			<em><?php echo esc_html_x( '“Études has saved us thousands of hours of work and has unlocked insights we never thought possible.”', 'Testimonial Text or Review Text Got From the Person', 'twentytwentyfour' ); ?></em>
 		</p>
 		<!-- /wp:paragraph -->
 
@@ -33,15 +31,11 @@
 			<!-- /wp:image -->
 
 			<!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","bottom":"0"}}}} -->
-			<p class="has-text-align-center" style="margin-top:var(--wp--preset--spacing--10);margin-bottom:0"><?php
-				echo esc_html_x( 'Annie Steiner', 'Name of Person Provided the Testimonial', 'twentytwentyfour' );
-			?></p>
+			<p class="has-text-align-center" style="margin-top:var(--wp--preset--spacing--10);margin-bottom:0"><?php echo esc_html_x( 'Annie Steiner', 'Name of Person Provided the Testimonial', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:paragraph {"align":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"300"}},"textColor":"contrast-3","fontSize":"small"} -->
-			<p class="has-text-align-center has-contrast-3-color has-text-color has-small-font-size" style="font-style:normal;font-weight:300"><?php
-				echo esc_html_x( 'CEO, Greenprint', 'Designation of Person Provided Testimonial', 'twentytwentyfour' );
-			?></p>
+			<p class="has-text-align-center has-contrast-3-color has-text-color has-small-font-size" style="font-style:normal;font-weight:300"><?php echo esc_html_x( 'CEO, Greenprint', 'Designation of Person Provided Testimonial', 'twentytwentyfour' ); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/testimonial-centered.php
+++ b/patterns/testimonial-centered.php
@@ -14,9 +14,9 @@
 	<div class="wp-block-group">
 		<!-- wp:paragraph {"align":"center","style":{"typography":{"lineHeight":"1.2"}},"textColor":"base","fontSize":"x-large","fontFamily":"heading"} -->
 		<p class="has-text-align-center has-base-color has-text-color has-heading-font-family has-x-large-font-size" style="line-height:1.2">
-			<em>
-				<?php echo esc_html_x( '“Études has saved us thousands of hours of work and has unlocked insights we never thought possible.”', 'Testimonial Text or Review Text Got From the Person', 'twentytwentyfour' ); ?>
-			</em>
+			<em><?php
+				echo esc_html_x( '“Études has saved us thousands of hours of work and has unlocked insights we never thought possible.”', 'Testimonial Text or Review Text Got From the Person', 'twentytwentyfour' );
+			?></em>
 		</p>
 		<!-- /wp:paragraph -->
 
@@ -33,15 +33,15 @@
 			<!-- /wp:image -->
 
 			<!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","bottom":"0"}}}} -->
-			<p class="has-text-align-center" style="margin-top:var(--wp--preset--spacing--10);margin-bottom:0">
-				<?php echo esc_html_x( 'Annie Steiner', 'Name of Person Provided the Testimonial', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-text-align-center" style="margin-top:var(--wp--preset--spacing--10);margin-bottom:0"><?php
+				echo esc_html_x( 'Annie Steiner', 'Name of Person Provided the Testimonial', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:paragraph {"align":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"300"}},"textColor":"contrast-3","fontSize":"small"} -->
-			<p class="has-text-align-center has-contrast-3-color has-text-color has-small-font-size" style="font-style:normal;font-weight:300">
-				<?php echo esc_html_x( 'CEO, Greenprint', 'Designation of Person Provided Testimonial', 'twentytwentyfour' ); ?>
-			</p>
+			<p class="has-text-align-center has-contrast-3-color has-text-color has-small-font-size" style="font-style:normal;font-weight:300"><?php
+				echo esc_html_x( 'CEO, Greenprint', 'Designation of Person Provided Testimonial', 'twentytwentyfour' );
+			?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/text-centered-cta-subscribe.php
+++ b/patterns/text-centered-cta-subscribe.php
@@ -16,24 +16,24 @@
 		<!-- /wp:spacer -->
 
 		<!-- wp:heading {"textAlign":"center","fontSize":"x-large"} -->
-		<h2 class="wp-block-heading has-text-align-center has-x-large-font-size">
-			<?php echo esc_html_x( 'Join 900+ subscribers', 'Sample text for Subscriber Heading with numbers', 'twentytwentyfour' ); ?>
-		</h2>
+		<h2 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php
+			echo esc_html_x( 'Join 900+ subscribers', 'Sample text for Subscriber Heading with numbers', 'twentytwentyfour' );
+		?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center">
-			<?php echo esc_html_x( 'Stay in the loop with everything you need to know.', 'Sample text for Subscriber Description', 'twentytwentyfour' ); ?>
-		</p>
+		<p class="has-text-align-center"><?php
+			echo esc_html_x( 'Stay in the loop with everything you need to know.', 'Sample text for Subscriber Description', 'twentytwentyfour' );
+		?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 		<div class="wp-block-buttons">
 			<!-- wp:button -->
 			<div class="wp-block-button">
-				<a class="wp-block-button__link wp-element-button">
-					<?php echo esc_html_x( 'Sign up', 'Sample text for Sign Up Button', 'twentytwentyfour' ); ?>
-				</a>
+				<a class="wp-block-button__link wp-element-button"><?php
+					echo esc_html_x( 'Sign up', 'Sample text for Sign Up Button', 'twentytwentyfour' );
+				?></a>
 			</div>
 			<!-- /wp:button -->
 		</div>

--- a/patterns/text-centered-cta-subscribe.php
+++ b/patterns/text-centered-cta-subscribe.php
@@ -16,24 +16,18 @@
 		<!-- /wp:spacer -->
 
 		<!-- wp:heading {"textAlign":"center","fontSize":"x-large"} -->
-		<h2 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php
-			echo esc_html_x( 'Join 900+ subscribers', 'Sample text for Subscriber Heading with numbers', 'twentytwentyfour' );
-		?></h2>
+		<h2 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html_x( 'Join 900+ subscribers', 'Sample text for Subscriber Heading with numbers', 'twentytwentyfour' ); ?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center"><?php
-			echo esc_html_x( 'Stay in the loop with everything you need to know.', 'Sample text for Subscriber Description', 'twentytwentyfour' );
-		?></p>
+		<p class="has-text-align-center"><?php echo esc_html_x( 'Stay in the loop with everything you need to know.', 'Sample text for Subscriber Description', 'twentytwentyfour' ); ?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 		<div class="wp-block-buttons">
 			<!-- wp:button -->
 			<div class="wp-block-button">
-				<a class="wp-block-button__link wp-element-button"><?php
-					echo esc_html_x( 'Sign up', 'Sample text for Sign Up Button', 'twentytwentyfour' );
-				?></a>
+				<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Sign up', 'Sample text for Sign Up Button', 'twentytwentyfour' ); ?></a>
 			</div>
 			<!-- /wp:button -->
 		</div>

--- a/patterns/text-centered-title.php
+++ b/patterns/text-centered-title.php
@@ -12,8 +12,7 @@
 
 	<!-- wp:heading {"textAlign":"center","level":1,"fontSize":"x-large","level":1} -->
 	<h1 class="wp-block-heading has-text-align-center has-x-large-font-size">
-		<em>
-			<?php
+		<em><?php
 			/* Translators: About link placeholder */
 			$about_link = '<a href="#" rel="nofollow">' . esc_html__( 'Money Studies', 'twentytwentyfour' ) . '</a>';
 			echo sprintf(
@@ -21,8 +20,7 @@
 				esc_html__( 'I write about finance, management and economy, my book “%1$s” is out now.', 'twentytwentyfour' ),
 				$about_link
 			);
-			?>
-		</em>
+		?></em>
 	</h1>
 	<!-- /wp:heading -->
 </div>

--- a/patterns/text-centered-title.php
+++ b/patterns/text-centered-title.php
@@ -12,15 +12,17 @@
 
 	<!-- wp:heading {"textAlign":"center","level":1,"fontSize":"x-large","level":1} -->
 	<h1 class="wp-block-heading has-text-align-center has-x-large-font-size">
-		<em><?php
-			/* Translators: About link placeholder */
+		<em>
+		<?php
+		/* Translators: About link placeholder */
 			$about_link = '<a href="#" rel="nofollow">' . esc_html__( 'Money Studies', 'twentytwentyfour' ) . '</a>';
 			echo sprintf(
 				/* Translators: About text placeholder */
 				esc_html__( 'I write about finance, management and economy, my book “%1$s” is out now.', 'twentytwentyfour' ),
 				$about_link
 			);
-		?></em>
+			?>
+		</em>
 	</h1>
 	<!-- /wp:heading -->
 </div>

--- a/patterns/text-title-left-image-right.php
+++ b/patterns/text-title-left-image-right.php
@@ -17,27 +17,27 @@
 			<div class="wp-block-group" style="min-height:100%">
 
 				<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large","fontFamily":"heading"} -->
-				<p class="has-heading-font-family has-x-large-font-size" style="line-height:1.2">
-					<?php echo esc_html_x( 'Études offers comprehensive consulting, management, design, and research solutions. Every architectural endeavor is an opportunity to shape the future.', 'Headline for the About pattern', 'twentytwentyfour' ); ?>
-				</p>
+				<p class="has-heading-font-family has-x-large-font-size" style="line-height:1.2"><?php
+					echo esc_html_x( 'Études offers comprehensive consulting, management, design, and research solutions. Every architectural endeavor is an opportunity to shape the future.', 'Headline for the About pattern', 'twentytwentyfour' );
+				?></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:group {"layout":{"type":"constrained","contentSize":"300px","justifyContent":"left"}} -->
 				<div class="wp-block-group">
 
 					<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fixed","flexSize":"50%"}}} -->
-					<p>
-						<?php echo esc_html_x( 'Leaving an indelible mark on the landscape of tomorrow.', 'Description for the About pattern', 'twentytwentyfour' ); ?>
-					</p>
+					<p><?php
+						echo esc_html_x( 'Leaving an indelible mark on the landscape of tomorrow.', 'Description for the About pattern', 'twentytwentyfour' );
+					?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:buttons -->
 					<div class="wp-block-buttons">
 						<!-- wp:button -->
 						<div class="wp-block-button">
-							<a class="wp-block-button__link wp-element-button">
-								<?php echo esc_html_x( 'About us', 'Call to Action button text', 'twentytwentyfour' ); ?>
-							</a>
+							<a class="wp-block-button__link wp-element-button"><?php
+								echo esc_html_x( 'About us', 'Call to Action button text', 'twentytwentyfour' );
+							?></a>
 						</div>
 						<!-- /wp:button -->
 					</div>

--- a/patterns/text-title-left-image-right.php
+++ b/patterns/text-title-left-image-right.php
@@ -17,27 +17,21 @@
 			<div class="wp-block-group" style="min-height:100%">
 
 				<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"x-large","fontFamily":"heading"} -->
-				<p class="has-heading-font-family has-x-large-font-size" style="line-height:1.2"><?php
-					echo esc_html_x( 'Études offers comprehensive consulting, management, design, and research solutions. Every architectural endeavor is an opportunity to shape the future.', 'Headline for the About pattern', 'twentytwentyfour' );
-				?></p>
+				<p class="has-heading-font-family has-x-large-font-size" style="line-height:1.2"><?php echo esc_html_x( 'Études offers comprehensive consulting, management, design, and research solutions. Every architectural endeavor is an opportunity to shape the future.', 'Headline for the About pattern', 'twentytwentyfour' ); ?></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:group {"layout":{"type":"constrained","contentSize":"300px","justifyContent":"left"}} -->
 				<div class="wp-block-group">
 
 					<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fixed","flexSize":"50%"}}} -->
-					<p><?php
-						echo esc_html_x( 'Leaving an indelible mark on the landscape of tomorrow.', 'Description for the About pattern', 'twentytwentyfour' );
-					?></p>
+					<p><?php echo esc_html_x( 'Leaving an indelible mark on the landscape of tomorrow.', 'Description for the About pattern', 'twentytwentyfour' ); ?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:buttons -->
 					<div class="wp-block-buttons">
 						<!-- wp:button -->
 						<div class="wp-block-button">
-							<a class="wp-block-button__link wp-element-button"><?php
-								echo esc_html_x( 'About us', 'Call to Action button text', 'twentytwentyfour' );
-							?></a>
+							<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'About us', 'Call to Action button text', 'twentytwentyfour' ); ?></a>
 						</div>
 						<!-- /wp:button -->
 					</div>


### PR DESCRIPTION
Fixes the spaces at the beginning and and of each translated string for all patterns. Due to the formatting of the pattern files, unfortunately spaces appear. Putting the opening and closing PHP tags on the same line as the HTML tags prevents extra spaces being created in the editor.