### PR TITLE
Fix duplicate spacing scale bug

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -602,7 +602,7 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
 				},
-				"css": "& .wp-block-post-terms__prefix{color: var(--wp--preset--color--contrast-2);}"
+				"css":"& .wp-block-post-terms__prefix{color: var(--wp--preset--color--contrast-2);}"
 			},
 			"core/post-title": {
 				"elements": {

--- a/theme.json
+++ b/theme.json
@@ -159,6 +159,9 @@
 			"wideSize": "1280px"
 		},
 		"spacing": {
+			"spacingScale": {
+				"steps": 0
+			},
 			"spacingSizes": [
 				{
 					"name": "1",
@@ -599,7 +602,7 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
 				},
-				"css":"& .wp-block-post-terms__prefix{color: var(--wp--preset--color--contrast-2);}"
+				"css": "& .wp-block-post-terms__prefix{color: var(--wp--preset--color--contrast-2);}"
 			},
 			"core/post-title": {
 				"elements": {


### PR DESCRIPTION
**Description**

Fixes: https://github.com/WordPress/gutenberg/issues/55276

Because the default spacing scale is not disabled this is generated along with the custom spacing sizes.

**Screenshots**
Before:
<img width="283" alt="Screenshot 2023-10-12 at 11 48 36 AM" src="https://github.com/WordPress/twentytwentyfour/assets/3629020/7b9e8574-e80e-4572-a720-f5b22e7cd3c6">

After:
<img width="280" alt="Screenshot 2023-10-12 at 11 47 24 AM" src="https://github.com/WordPress/twentytwentyfour/assets/3629020/2ad4c6d8-7c89-40f3-8af5-476a997f07b9">

**Testing Instructions**

- Add a group block and in the block styles panel check that the padding section shows a stepped slider, and not a select list with duplicated size options

**Contributors**

<!-- Please ensure anyone who contributed on linked issues and within this pull request have _AT LEAST_ their GitHub Username listed in the `CONTRIBUTORS.md` file as part of this PR. -->
