### PR TITLE
Fix plain quote with background padding issue

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -660,7 +660,7 @@
 				"color": {
 					"background": "var(--wp--preset--color--base-2)"
 				},
-				"css": "& :where(p) {margin-block-start:0;margin-block-end:calc(var(--wp--preset--spacing--10) + 0.5rem);} &.has-text-align-right.is-style-plain, .rtl .is-style-plain.wp-block-quote:not(.has-text-align-center):not(.has-text-align-left){border-width: 0 2px 0 0;padding-left: 0;padding-right:calc(var(--wp--preset--spacing--20) + 0.5rem);} &.has-text-align-left.is-style-plain, body:not(.rtl) .is-style-plain.wp-block-quote:not(.has-text-align-center):not(.has-text-align-right){border-width: 0 0 0 2px;padding-right: 0;padding-left:calc(var(--wp--preset--spacing--20) + 0.5rem);}",
+				"css": "& :where(p) {margin-block-start:0;margin-block-end:calc(var(--wp--preset--spacing--10) + 0.5rem);} &.has-text-align-right.is-style-plain, .rtl .is-style-plain.wp-block-quote:not(.has-text-align-center):not(.has-text-align-left){border-width: 0 2px 0 0;padding-left:calc(var(--wp--preset--spacing--20) + 0.5rem);padding-right:calc(var(--wp--preset--spacing--20) + 0.5rem);} &.has-text-align-left.is-style-plain, body:not(.rtl) .is-style-plain.wp-block-quote:not(.has-text-align-center):not(.has-text-align-right){border-width: 0 0 0 2px;padding-left:calc(var(--wp--preset--spacing--20) + 0.5rem);padding-right:calc(var(--wp--preset--spacing--20) + 0.5rem)}",
 				"elements": {
 					"cite": {
 						"typography": {


### PR DESCRIPTION
**Description**

The recent update for the plain quote block variation showed an issue when the block was used with a background color. Updated the CSS to have the same padding both left and right.

**Screenshots**

<img width="642" alt="CleanShot 2023-10-12 at 12 30 45@2x" src="https://github.com/WordPress/twentytwentyfour/assets/7585600/dbaaf7f1-6079-45c4-80c0-8aa87351f40f">


**Testing Instructions**

1. Open/create post or page
2. Add a quote block
3. Add some content so there's at least two or three lines
4. Change the background color of the quote block
5. The content will have the same amount of padding left and right
