### PR TITLE
fixed plain quote with background padding issue#611

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -703,7 +703,7 @@
 							"padding": {
 								"bottom": "var(--wp--preset--spacing--20)",
 								"left": "calc(var(--wp--preset--spacing--20) + 0.5rem)",
-								"right": "0",
+								"right": "calc(var(--wp--preset--spacing--20) + 0.5rem)",
 								"top": "var(--wp--preset--spacing--20)"
 							}
 						},


### PR DESCRIPTION
**Description**

Hello Team,

I have worked on the issue https://github.com/WordPress/twentytwentyfour/issues/611 and resolved it from my end. Here, I have added my PR.

**Screenshots**

**Back-end:**
![fixed_611_back_end](https://github.com/WordPress/twentytwentyfour/assets/53076293/62ae5eb6-43b0-436a-a7ad-9dd5e9422cc8)

**Front-end:**
![fixed_611_front_end](https://github.com/WordPress/twentytwentyfour/assets/53076293/d70c14ad-122a-4bc5-9781-725ceaaea287)

**Testing Instructions**

- Go to page Type / to choose a block
- Select "Quote" block
- Add dummy text
- Click on block setting and try to change the style to "Plain"
- Then change the text color & background color.
