### PR TITLE
Add offset image grid patterns

### DIFF
--- a/patterns/gallery-offset-image-grid-2-col.php
+++ b/patterns/gallery-offset-image-grid-2-col.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Offset Image Grid, 3 Columns
- * Slug: twentytwentyfour/gallery-offset-image-grid-3-col
+ * Title: Offset Image Grid, 2 Columns
+ * Slug: twentytwentyfour/gallery-offset-image-grid-2-col
  * Categories: gallery, featured, portfolio
  * Keywords: project, images, media, masonry, columns
  * Viewport width: 1400
@@ -12,14 +12,6 @@
 <div class="wp-block-columns alignwide" style="margin-top:0;margin-bottom:0"><!-- wp:column {"style":{"spacing":{"blockGap":"0"}}} -->
 <div class="wp-block-column"><!-- wp:image {"aspectRatio":"4/3","scale":"cover","className":"is-style-rounded"} -->
 <figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:4/3;object-fit:cover"/></figure>
-<!-- /wp:image -->
-
-<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:image {"aspectRatio":"3/4","scale":"cover","className":"is-style-rounded"} -->
-<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:3/4;object-fit:cover"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:spacer {"height":"var:preset|spacing|50"} -->
@@ -46,36 +38,6 @@
 
 <!-- wp:image {"aspectRatio":"1","scale":"cover","className":"is-style-rounded"} -->
 <figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:1;object-fit:cover"/></figure>
-<!-- /wp:image -->
-
-<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:image {"aspectRatio":"1","scale":"cover","className":"is-style-rounded"} -->
-<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:1;object-fit:cover"/></figure>
-<!-- /wp:image --></div>
-<!-- /wp:column -->
-
-<!-- wp:column {"style":{"spacing":{"blockGap":"0"}}} -->
-<div class="wp-block-column"><!-- wp:image {"aspectRatio":"3/4","scale":"cover","className":"is-style-rounded"} -->
-<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:3/4;object-fit:cover"/></figure>
-<!-- /wp:image -->
-
-<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:image {"aspectRatio":"3/4","scale":"cover","className":"is-style-rounded"} -->
-<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:3/4;object-fit:cover"/></figure>
-<!-- /wp:image -->
-
-<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:image {"aspectRatio":"16/9","scale":"cover","className":"is-style-rounded"} -->
-<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:16/9;object-fit:cover"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>

--- a/patterns/gallery-offset-image-grid-3-col.php
+++ b/patterns/gallery-offset-image-grid-3-col.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Title: Gallery Offset Image Grid, 3 Columns
+ * Slug: twentytwentyfour/gallery-offset-image-grid-3-col
+ * Categories: gallery, featured, portfolio
+ * Keywords: project, images, media, masonry, columns
+ * Viewport width: 1400
+ */
+?>
+<!-- wp:group {"metadata":{"name":"Portfolio Images"},"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"var:preset|spacing|40"},"margin":{"top":"0","bottom":"0"}}}} -->
+<div class="wp-block-columns alignwide" style="margin-top:0;margin-bottom:0"><!-- wp:column {"style":{"spacing":{"blockGap":"0"}}} -->
+<div class="wp-block-column"><!-- wp:image {"aspectRatio":"4/3","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"3/4","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:3/4;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"3/4","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:3/4;object-fit:cover"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"blockGap":"0"}}} -->
+<div class="wp-block-column"><!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"3/4","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:3/4;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"1","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:1;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"1","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:1;object-fit:cover"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"blockGap":"0"}}} -->
+<div class="wp-block-column"><!-- wp:image {"aspectRatio":"3/4","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:3/4;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"3/4","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:3/4;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"16/9","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:16/9;object-fit:cover"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->

--- a/patterns/gallery-offset-image-grid.php
+++ b/patterns/gallery-offset-image-grid.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Title: Gallery Offset Image Grid
+ * Slug: twentytwentyfour/gallery-offset-image-grid
+ * Categories: gallery, featured, portfolio
+ * Keywords: project, images, media, masonry, columns
+ * Viewport width: 1400
+ */
+?>
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"},"metadata":{"name":"Portfolio Images"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"var:preset|spacing|40"},"margin":{"top":"0","bottom":"0"}}}} -->
+<div class="wp-block-columns alignwide" style="margin-top:0;margin-bottom:0"><!-- wp:column {"style":{"spacing":{"blockGap":"0"}}} -->
+<div class="wp-block-column"><!-- wp:image {"aspectRatio":"4/3","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"3/4","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:3/4;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"3/4","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:3/4;object-fit:cover"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"blockGap":"0"}}} -->
+<div class="wp-block-column"><!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"3/4","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:3/4;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"1","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:1;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"1","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:1;object-fit:cover"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"blockGap":"0"}}} -->
+<div class="wp-block-column"><!-- wp:image {"aspectRatio":"3/4","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:3/4;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"3/4","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:3/4;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"16/9","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:16/9;object-fit:cover"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"blockGap":"0"}}} -->
+<div class="wp-block-column"><!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"1","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:1;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"16/9","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:16/9;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"aspectRatio":"9/16","scale":"cover","className":"is-style-rounded"} -->
+<figure class="wp-block-image is-style-rounded"><img alt="" style="aspect-ratio:9/16;object-fit:cover"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->

--- a/patterns/gallery-offset-image-grid.php
+++ b/patterns/gallery-offset-image-grid.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Gallery Offset Image Grid
- * Slug: twentytwentyfour/gallery-offset-image-grid
+ * Title: Offset Image Grid, 4 Columns
+ * Slug: twentytwentyfour/gallery-offset-image-grid-4-col
  * Categories: gallery, featured, portfolio
  * Keywords: project, images, media, masonry, columns
  * Viewport width: 1400


### PR DESCRIPTION
**Description**

Adds patterns that leverage the neat portfolio grid, but instead of query loop it's image blocks.

Otherwise, you can’t actually make a portfolio _with_ a blog as-is. This would allow you to add a separate portfolio gallery to any page. 


**Screenshots**

![CleanShot 2023-10-12 at 15 21 41](https://github.com/WordPress/twentytwentyfour/assets/1813435/27c9a4d5-039e-4e85-a8a7-46c22e19469e)

