### PR TITLE
Rename footers appropriately

### DIFF
--- a/patterns/footer-centered-logo-nav.php
+++ b/patterns/footer-centered-logo-nav.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Minimal centered footer with logo and navigation
- * Slug: twentytwentyfour/footer-writer
+ * Title: Footer with centered logo and navigation
+ * Slug: twentytwentyfour/footer-centered-logo-nav
  * Categories: footer
  * Block Types: core/template-part/footer
  */

--- a/patterns/footer-colophon-3-col.php
+++ b/patterns/footer-colophon-3-col.php
@@ -35,12 +35,10 @@
 				<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 				<div class="wp-block-group">
 					<!-- wp:heading {"level":3,"fontSize":"medium","fontFamily":"body"} -->
-					<h3 class="wp-block-heading has-body-font-family has-medium-font-size"><?php esc_html_e( 'Contact Me', 'twentytwentyfour' ); ?></h3>
+					<h3 class="wp-block-heading has-body-font-family has-medium-font-size"><?php esc_html_e( 'Contact', 'twentytwentyfour' ); ?></h3>
 					<!-- /wp:heading -->
 					<!-- wp:paragraph -->
-					<p>
-						<a href="#"><?php echo esc_html_x( 'info@example.com', 'Example email in site footer', 'twentytwentyfour' ); ?></a>
-					</p>
+					<p><a href="#"><?php echo esc_html_x( 'info@example.com', 'Example email in site footer', 'twentytwentyfour' ); ?></a></p>
 					<!-- /wp:paragraph -->
 				</div>
 				<!-- /wp:group -->
@@ -55,12 +53,10 @@
 						<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 						<div class="wp-block-group">
 							<!-- wp:heading {"level":3,"fontSize":"medium","fontFamily":"body"} -->
-							<h3 class="wp-block-heading has-body-font-family has-medium-font-size"><?php esc_html_e( 'Follow Me', 'twentytwentyfour' ); ?></h3>
+							<h3 class="wp-block-heading has-body-font-family has-medium-font-size"><?php esc_html_e( 'Follow', 'twentytwentyfour' ); ?></h3>
 							<!-- /wp:heading -->
 							<!-- wp:paragraph -->
-							<p>
-								<a href="#"><?php esc_html_e( 'Instagram', 'twentytwentyfour' ); ?></a> / <a href="#"><?php esc_html_e( 'Facebook', 'twentytwentyfour' ); ?></a>
-							</p>
+							<p><a href="#"><?php esc_html_e( 'Instagram', 'twentytwentyfour' ); ?></a> / <a href="#"><?php esc_html_e( 'Facebook', 'twentytwentyfour' ); ?></a></p>
 							<!-- /wp:paragraph -->
 						</div>
 						<!-- /wp:group -->

--- a/patterns/footer-colophon-3-col.php
+++ b/patterns/footer-colophon-3-col.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Two column footer with colophon
- * Slug: twentytwentyfour/footer-portfolio
+ * Title: Footer with colophon, 3 columns
+ * Slug: twentytwentyfour/footer-colophon-3-col
  * Categories: footer
  * Block Types: core/template-part/footer
  */

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -82,7 +82,7 @@
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 				<div class="wp-block-group">
 					<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontFamily":"body"} -->
-					<h2 class="wp-block-heading has-medium-font-size has-body-font-family" style="font-style:normal;font-weight:600"><?php esc_html_e( 'Social Media', 'twentytwentyfour' ); ?></h2>
+					<h2 class="wp-block-heading has-medium-font-size has-body-font-family" style="font-style:normal;font-weight:600"><?php esc_html_e( 'Social', 'twentytwentyfour' ); ?></h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Three column footer with colophon
+ * Title: Footer with colophon, four columns
  * Slug: twentytwentyfour/footer
  * Categories: footer
  * Block Types: core/template-part/footer


### PR DESCRIPTION
**Description**

Closes #628 . Related in part to #548 (shouldn't need to update the footer patterns in that fix). Also addresses minor text string changes (#584) to make the content a bit more general (i.e. work for personal, and business sites). 

**Screenshots**
![CleanShot 2023-10-12 at 16 00 07](https://github.com/WordPress/twentytwentyfour/assets/1813435/3c3aa0bc-ef95-4901-9ea4-599f7187e70f)


**Testing Instructions**
Go to the site editor > footers view and see the three footer options. There should be no changes to the footers, only the titles/slugs.  Then search for `portfolio` and you shouldn't see the footer portfolio. 
