### PR TITLE
Remove core/post-content from the Writer Home pattern

### DIFF
--- a/patterns/page-06-writer-home.php
+++ b/patterns/page-06-writer-home.php
@@ -4,7 +4,6 @@
  * Slug: twentytwentyfour/writer-home
  * Categories: text, page
  * Keywords: page, starter
- * Block Types: core/post-content
  * Post Types: page, wp_template
  * Viewport width: 1400
  */


### PR DESCRIPTION
**Description**

Closes #627. 

> I propose we remove the "Writer Home Page" from the starter patterns. It's more of a blogroll view and not likely to be used on subsequent pages. I think it'd be more confusing to add it here, as you would end up expecting that to be your blog (but it's not).

**Screenshots**

![CleanShot 2023-10-12 at 16 06 16](https://github.com/WordPress/twentytwentyfour/assets/1813435/eb58a94f-e3f0-49c7-9d35-f07dac01ae52)


**Testing Instructions**

The "Writer Home Page" should not show up in the starter pattern selection modal. Add a new page to invoke the modal. 
