### PR TITLE
Tweak quote spacing

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -106,3 +106,4 @@
 | @alishabajra | @alishabajracharya27 |
 | @Yos0107 | @yosephtamang |
 | @gregoryfu |  |
+| @enodekciw | @enodekciw |

--- a/theme.json
+++ b/theme.json
@@ -667,7 +667,7 @@
 				"color": {
 					"background": "var(--wp--preset--color--base-2)"
 				},
-				"css": "& :where(p) {margin-block-start:0;margin-block-end:calc(var(--wp--preset--spacing--10) + 0.5rem);} &.has-text-align-right.is-style-plain, .rtl .is-style-plain.wp-block-quote:not(.has-text-align-center):not(.has-text-align-left){border-width: 0 2px 0 0;padding-left: 0;padding-right:calc(var(--wp--preset--spacing--20) + 0.5rem);} &.has-text-align-left.is-style-plain, body:not(.rtl) .is-style-plain.wp-block-quote:not(.has-text-align-center):not(.has-text-align-right){border-width: 0 0 0 2px;padding-right: 0;padding-left:calc(var(--wp--preset--spacing--20) + 0.5rem);}",
+				"css": "& :where(p) {margin-block-start:0;margin-block-end:calc(var(--wp--preset--spacing--10) + 0.5rem);} & :where(:last-child) {margin-block-end:0;} &.has-text-align-right.is-style-plain, .rtl .is-style-plain.wp-block-quote:not(.has-text-align-center):not(.has-text-align-left){border-width: 0 2px 0 0;padding-left: 0;padding-right:calc(var(--wp--preset--spacing--20) + 0.5rem);} &.has-text-align-left.is-style-plain, body:not(.rtl) .is-style-plain.wp-block-quote:not(.has-text-align-center):not(.has-text-align-right){border-width: 0 0 0 2px;padding-right: 0;padding-left:calc(var(--wp--preset--spacing--20) + 0.5rem);}",
 				"elements": {
 					"cite": {
 						"typography": {


### PR DESCRIPTION
**Description**

When no `<cite>` exists on `core/quote` block, margin-bottom of the last child element is stacking with `<blockquote>` padding-bottom. This should make Quote block spacing more consistent.

Closes #620 

**Before and After**

Original layout:
![core-quote-before](https://github.com/WordPress/twentytwentyfour/assets/2080743/c2e1ec60-2bf7-4093-b21d-72b3d6d8de11)

Updated layout:
![core-quote-after](https://github.com/WordPress/twentytwentyfour/assets/2080743/59009a8e-02b7-431a-bb18-489803d3e486)

