### PR TITLE
Rename Writer patterns/templates to Blogging

### DIFF
--- a/patterns/page-06-blogging-home.php
+++ b/patterns/page-06-blogging-home.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Writer Home Page
- * Slug: twentytwentyfour/writer-home
+ * Title: Blogging Home
+ * Slug: twentytwentyfour/blogging-home
  * Categories: text, page
  * Keywords: page, starter
  * Post Types: page, wp_template

--- a/patterns/template-archive-blogging.php
+++ b/patterns/template-archive-blogging.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Title: Writer Index Template
- * Slug: twentytwentyfour/template-index-writer
- * Template Types: index, home
+ * Title: Blogging Archive
+ * Slug: twentytwentyfour/template-archive-blogging
+ * Template Types: archive, category, tag, author, date
  * Viewport width: 1400
  * Inserter: no
  */
@@ -12,9 +12,7 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0","margin":{"top":"0"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:0">
-	<!-- wp:heading {"level":1,"style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"var:preset|spacing|50"}}}} -->
-	<h1 class="wp-block-heading" style="padding-top:var(--wp--preset--spacing--50);line-height:1"><?php esc_html_e( 'Watch, Read, Listen', 'twentytwentyfour' ); ?></h1>
-	<!-- /wp:heading -->
+	<!-- wp:query-title {"type":"archive","style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"var:preset|spacing|50"}}}} /-->
 
 	<!-- wp:pattern {"slug":"twentytwentyfour/posts-one-column"} /-->
 </main>

--- a/patterns/template-home-blogging.php
+++ b/patterns/template-home-blogging.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Writer Home Template
- * Slug: twentytwentyfour/template-home-writer
+ * Title: Blogging Home
+ * Slug: twentytwentyfour/template-home-blogging
  * Template Types: front-page, index, home, page
  * Viewport width: 1400
  * Inserter: no
@@ -13,7 +13,7 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"},"tagName":"main"} -->
 <main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 
-	<!-- wp:pattern {"slug":"twentytwentyfour/writer-home"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfour/blogging-home"} /-->
 
 </main>
 <!-- /wp:group -->

--- a/patterns/template-index-blogging.php
+++ b/patterns/template-index-blogging.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Title: Writer Archive Template
- * Slug: twentytwentyfour/template-archive-writer
- * Template Types: archive, category, tag, author, date
+ * Title: Blogging Index
+ * Slug: twentytwentyfour/template-index-blogging
+ * Template Types: index, home
  * Viewport width: 1400
  * Inserter: no
  */
@@ -12,7 +12,9 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0","margin":{"top":"0"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:0">
-	<!-- wp:query-title {"type":"archive","style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"var:preset|spacing|50"}}}} /-->
+	<!-- wp:heading {"level":1,"style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"var:preset|spacing|50"}}}} -->
+	<h1 class="wp-block-heading" style="padding-top:var(--wp--preset--spacing--50);line-height:1"><?php esc_html_e( 'Watch, Read, Listen', 'twentytwentyfour' ); ?></h1>
+	<!-- /wp:heading -->
 
 	<!-- wp:pattern {"slug":"twentytwentyfour/posts-one-column"} /-->
 </main>

--- a/patterns/template-search-writer.php
+++ b/patterns/template-search-writer.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Writer Search Results Template
- * Slug: twentytwentyfour/template-search-writer
+ * Title: Blogging Search Results
+ * Slug: twentytwentyfour/template-search-blogging
  * Template Types: search
  * Viewport width: 1400
  * Inserter: no


### PR DESCRIPTION
I've renamed all "Writer" references in patterns and templates to "Blogging". I decided against "Blog", as something like "Blog Home", "Blog Search", "Blog Index", "Blog Archive" would be too confusing with already existing WordPress terminology.