### PR TITLE
Fix button padding in style variations

### DIFF
--- a/styles/fossil.json
+++ b/styles/fossil.json
@@ -165,14 +165,6 @@
 					"background": "var(--wp--preset--color--contrast-2)",
 					"text": "var(--wp--preset--color--white)"
 				},
-				"spacing": {
-					"padding": {
-						"bottom": "0.9rem",
-						"left": "2rem",
-						"right": "2rem",
-						"top": "0.9rem"
-					}
-				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--heading)",
 					"fontSize": "var(--wp--preset--font-size--small)",

--- a/styles/sandstorm.json
+++ b/styles/sandstorm.json
@@ -127,14 +127,6 @@
 						}
 					}
 				},
-				"spacing": {
-					"padding": {
-						"bottom": "var(--wp--preset--spacing--10)",
-						"left": "var(--wp--preset--spacing--20)",
-						"right": "var(--wp--preset--spacing--20)",
-						"top": "var(--wp--preset--spacing--10)"
-					}
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--medium)",
 					"textTransform": "capitalize"


### PR DESCRIPTION
As discussed in #569, the size of buttons in the Sandstorm and Fossil style variations should match with all other buttons. Removing extra padding from the style variations.