### PR TITLE
Remove button border and fix outline variation padding inconsistencies

### DIFF
--- a/styles/fossil.json
+++ b/styles/fossil.json
@@ -198,9 +198,6 @@
 				":hover": {
 					"color": {
 						"background": "var(--wp--preset--color--contrast)"
-					},
-					"border": {
-						"color": "var(--wp--preset--color--contrast)"
 					}
 				}
 			},

--- a/styles/fossil.json
+++ b/styles/fossil.json
@@ -138,8 +138,7 @@
 							}
 						},
 						"border": {
-							"style": "solid",
-							"width": "1px"
+							"width": "2px"
 						}
 					}
 				}

--- a/styles/fossil.json
+++ b/styles/fossil.json
@@ -131,10 +131,10 @@
 					"outline": {
 						"spacing": {
 							"padding": {
-								"bottom": "calc(0.9rem - 1px)",
-								"left": "calc(2rem - 1px)",
-								"right": "calc(2rem - 1px)",
-								"top": "calc(0.9rem - 1px)"
+								"bottom": "calc(0.9rem - 2px)",
+								"left": "calc(2rem - 2px)",
+								"right": "calc(2rem - 2px)",
+								"top": "calc(0.9rem - 2px)"
 							}
 						},
 						"border": {

--- a/styles/fossil.json
+++ b/styles/fossil.json
@@ -126,6 +126,24 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/button": {
+				"variations": {
+					"outline": {
+						"spacing": {
+							"padding": {
+								"bottom": "calc(0.9rem - 1px)",
+								"left": "calc(2rem - 1px)",
+								"right": "calc(2rem - 1px)",
+								"top": "calc(0.9rem - 1px)"
+							}
+						},
+						"border": {
+							"style": "solid",
+							"width": "1px"
+						}
+					}
+				}
+			},
 			"core/pullquote": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--large)",

--- a/theme.json
+++ b/theme.json
@@ -300,23 +300,17 @@
 			"core/button": {
 				"variations": {
 					"outline": {
-						"border": {
-							"bottom": {
-								"style": "solid",
-								"width": "1px"
-							},
-							"left": {
-								"style": "solid",
-								"width": "1px"
-							},
-							"right": {
-								"style": "solid",
-								"width": "1px"
-							},
-							"top": {
-								"style": "solid",
-								"width": "1px"
+						"spacing": {
+							"padding": {
+								"bottom": "calc(0.6rem - 1px)",
+								"left": "calc(1rem - 1px)",
+								"right": "calc(1rem - 1px)",
+								"top": "calc(0.6rem - 1px)"
 							}
+						},
+						"border": {
+							"style": "solid",
+							"width": "1px"
 						}
 					}
 				}
@@ -811,23 +805,7 @@
 				},
 				"border": {
 					"radius": ".33rem",
-					"color": "var(--wp--preset--color--contrast)",
-					"bottom": {
-						"style": "solid",
-						"width": "1px"
-					},
-					"left": {
-						"style": "solid",
-						"width": "1px"
-					},
-					"right": {
-						"style": "solid",
-						"width": "1px"
-					},
-					"top": {
-						"style": "solid",
-						"width": "1px"
-					}
+					"color": "var(--wp--preset--color--contrast)"
 				},
 				"color": {
 					"background": "var(--wp--preset--color--contrast)",

--- a/theme.json
+++ b/theme.json
@@ -309,7 +309,6 @@
 							}
 						},
 						"border": {
-							"style": "solid",
 							"width": "1px"
 						}
 					}


### PR DESCRIPTION
**Description**
An alternative to #645 and #643, which closes #613. Makes the buttons the intended size across variations, while also removing the border (which made it harder to change colors). 

This fix is applied to default  and fossil variations for now; the others do not have varying button styles (yet) so the fix in default is inherited there. 

**Screenshots**
![CleanShot 2023-10-13 at 15 07 01](https://github.com/WordPress/twentytwentyfour/assets/1813435/708b1a8c-54b4-4035-b0b4-83321473693c)

![CleanShot 2023-10-13 at 15 14 20](https://github.com/WordPress/twentytwentyfour/assets/1813435/9ddbddd1-4705-409b-8507-aaa27eb5780b)

