### PR TITLE
Fix hero area orphaned text

### DIFF
--- a/patterns/hero.php
+++ b/patterns/hero.php
@@ -9,33 +9,35 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained","contentSize":"","wideSize":""}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-	<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
+
+	<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"constrained","contentSize":"565px"}} -->
 	<div class="wp-block-group">
-		<!-- wp:heading {"textAlign":"center","fontSize":"x-large","level":1} -->
-		<h1 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html_x( 'A commitment to innovation and sustainability', 'Heading of the hero section', 'twentytwentyfour' ); ?></h1>
-		<!-- /wp:heading -->
 
-		<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
-		<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
+	<!-- wp:heading {"textAlign":"center","fontSize":"x-large","level":1} -->
+	<h1 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html_x( 'A commitment to innovation and sustainability', 'Heading of the hero section', 'twentytwentyfour' ); ?></h1>
+			<!-- /wp:heading -->
 
-		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center"><?php echo esc_html_x( 'Études is a pioneering firm that seamlessly merges creativity and functionality to redefine architectural excellence.', 'Content of the hero section', 'twentytwentyfour' ); ?></p>
-		<!-- /wp:paragraph -->
+			<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
+			<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
 
-		<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
-		<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center"><?php echo esc_html_x( 'Études is a pioneering firm that seamlessly merges creativity and functionality to redefine architectural excellence.', 'Content of the hero section', 'twentytwentyfour' ); ?></p>
+			<!-- /wp:paragraph -->
 
-		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-		<div class="wp-block-buttons">
-			<!-- wp:button -->
-			<div class="wp-block-button">
-				<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'About us', 'Button\'s label of the hero section', 'twentytwentyfour' ); ?></a>
+			<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
+			<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+
+			<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+			<div class="wp-block-buttons">
+				<!-- wp:button -->
+				<div class="wp-block-button">
+					<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'About us', 'Button\'s label of the hero section', 'twentytwentyfour' ); ?></a>
+				</div>
+				<!-- /wp:button -->
 			</div>
-			<!-- /wp:button -->
-		</div>
-		<!-- /wp:buttons -->
+			<!-- /wp:buttons -->
 	</div>
 	<!-- /wp:group -->
 

--- a/patterns/hero.php
+++ b/patterns/hero.php
@@ -17,16 +17,16 @@
 		<h1 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html_x( 'A commitment to innovation and sustainability', 'Heading of the hero section', 'twentytwentyfour' ); ?></h1>
 		<!-- /wp:heading -->
 
-		<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
-		<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- wp:spacer {"height":"1.25rem"} -->
+		<div style="height:1.25rem" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
 
 		<!-- wp:paragraph {"align":"center"} -->
 		<p class="has-text-align-center"><?php echo esc_html_x( 'Études is a pioneering firm that seamlessly merges creativity and functionality to redefine architectural excellence.', 'Content of the hero section', 'twentytwentyfour' ); ?></p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
-		<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- wp:spacer {"height":"1.25rem"} -->
+		<div style="height:1.25rem" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
 
 		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->

--- a/patterns/hero.php
+++ b/patterns/hero.php
@@ -13,31 +13,31 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"constrained","contentSize":"565px"}} -->
 	<div class="wp-block-group">
 
-	<!-- wp:heading {"textAlign":"center","fontSize":"x-large","level":1} -->
-	<h1 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html_x( 'A commitment to innovation and sustainability', 'Heading of the hero section', 'twentytwentyfour' ); ?></h1>
-			<!-- /wp:heading -->
+		<!-- wp:heading {"textAlign":"center","fontSize":"x-large","level":1} -->
+		<h1 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html_x( 'A commitment to innovation and sustainability', 'Heading of the hero section', 'twentytwentyfour' ); ?></h1>
+		<!-- /wp:heading -->
 
-			<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
-			<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
-			<!-- /wp:spacer -->
+		<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
+		<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
 
-			<!-- wp:paragraph {"align":"center"} -->
-			<p class="has-text-align-center"><?php echo esc_html_x( 'Études is a pioneering firm that seamlessly merges creativity and functionality to redefine architectural excellence.', 'Content of the hero section', 'twentytwentyfour' ); ?></p>
-			<!-- /wp:paragraph -->
+		<!-- wp:paragraph {"align":"center"} -->
+		<p class="has-text-align-center"><?php echo esc_html_x( 'Études is a pioneering firm that seamlessly merges creativity and functionality to redefine architectural excellence.', 'Content of the hero section', 'twentytwentyfour' ); ?></p>
+		<!-- /wp:paragraph -->
 
-			<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
-			<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
-			<!-- /wp:spacer -->
+		<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"1.25rem","selfStretch":"fixed"}}} -->
+		<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
 
-			<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-			<div class="wp-block-buttons">
-				<!-- wp:button -->
-				<div class="wp-block-button">
-					<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'About us', 'Button\'s label of the hero section', 'twentytwentyfour' ); ?></a>
-				</div>
-				<!-- /wp:button -->
+		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+		<div class="wp-block-buttons">
+			<!-- wp:button -->
+			<div class="wp-block-button">
+				<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'About us', 'Button\'s label of the hero section', 'twentytwentyfour' ); ?></a>
 			</div>
-			<!-- /wp:buttons -->
+			<!-- /wp:button -->
+		</div>
+		<!-- /wp:buttons -->
 	</div>
 	<!-- /wp:group -->
 

--- a/theme.json
+++ b/theme.json
@@ -270,15 +270,15 @@
 				{
 					"fluid": {
 						"min": "1.85rem",
-						"max": "2.46rem"
+						"max": "2.5rem"
 					},
 					"name": "Extra Large",
-					"size": "2.46rem",
+					"size": "2.5rem",
 					"slug": "x-large"
 				},
 				{
 					"fluid": {
-						"min": "2.46rem",
+						"min": "2.5rem",
 						"max": "3.27rem"
 					},
 					"name": "Extra Extra Large",


### PR DESCRIPTION
**Description**

Adjust the content area of the hero, as well as a slight tweak to the font size of the xxl size, so that the hero looks great out of the box across variations. 

**Screenshots**
![CleanShot 2023-10-13 at 16 05 27](https://github.com/WordPress/twentytwentyfour/assets/1813435/19d93ba2-72a7-4bb2-856a-5531c7521374)

![CleanShot 2023-10-13 at 16 05 44](https://github.com/WordPress/twentytwentyfour/assets/1813435/d5a187f9-a842-4851-a757-ef0e0119c9f3)

