### PR TITLE
Fix colors for calendar block

### DIFF
--- a/styles/rust.json
+++ b/styles/rust.json
@@ -94,6 +94,9 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/calendar": {
+				"css": ".wp-block-calendar table:where(:not(.has-text-color)) th{background-color:var(--wp--preset--color--contrast);color:var(--wp--preset--color--base);border-color:var(--wp--preset--color--contrast)} & table:where(:not(.has-text-color)) td{border-color:var(--wp--preset--color--contrast)}"
+			},
 			"core/comment-date": {
 				"color": {
 					"text": "var(--wp--preset--color--contrast)"

--- a/theme.json
+++ b/theme.json
@@ -319,6 +319,12 @@
 					"blockGap": "0.7rem"
 				}
 			},
+			"core/calendar": {
+				"color": {
+					"text": "var(--wp--preset--color--contrast)"
+				},
+				"css": ".wp-block-calendar table:where(:not(.has-text-color)) th{background-color:var(--wp--preset--color--contrast-2);color:var(--wp--preset--color--base);border-color:var(--wp--preset--color--contrast-2)} & table:where(:not(.has-text-color)) td{border-color:var(--wp--preset--color--contrast-2)}"
+			},
 			"core/categories": {
 				"spacing": {
 					"padding": {


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Closes https://github.com/WordPress/twentytwentyfour/issues/605

The block needs work for it not to need CSS but at this point in the cycle I don't think we can do much more than this.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

<img width="776" alt="Screenshot 2023-10-16 at 17 18 28" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/3cdb626b-bda4-4762-b193-fd0828c102c8">
<img width="778" alt="Screenshot 2023-10-16 at 17 16 14" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/9e742cca-080f-4db3-a027-148e95520cc9">
<img width="768" alt="Screenshot 2023-10-16 at 17 16 05" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/fb22ca90-809f-4893-888c-13133d7eccc1">
<img width="745" alt="Screenshot 2023-10-16 at 17 15 56" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/32007468-857f-4bec-b144-bfa4c3b0e9ba">
<img width="721" alt="Screenshot 2023-10-16 at 17 14 27" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/d1d84394-71e0-489c-b442-c8ad4be39a77">
<img width="772" alt="Screenshot 2023-10-16 at 17 14 19" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/4064eea8-0d20-4278-bf85-bbbf29393252">
<img width="760" alt="Screenshot 2023-10-16 at 17 14 04" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/60fc54e9-1f94-4cd4-bbed-dc3d70f799b9">


I tested on all variations and I could change the colors to a custom one via the editor:

<img width="1280" alt="Screenshot 2023-10-16 at 17 20 56" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/514ff804-5a9f-46d3-a87a-eace05fc87ca">
