### PR TITLE
Fix potfolio home pattern

### DIFF
--- a/patterns/hidden-intro-text-left.php
+++ b/patterns/hidden-intro-text-left.php
@@ -11,10 +11,10 @@
 <div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:group {"align":"wide","layout":{"type":"constrained","justifyContent":"left","contentSize":"890px"}} -->
+<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide">
-	<!-- wp:heading {"level":1,"style":{"typography":{"lineHeight":"1.2"}},"fontSize":"xx-large"} -->
-	<h1 class="wp-block-heading has-xx-large-font-size" style="line-height:1.2"><?php echo wp_kses_post( __( 'I’m <em>Leia Acosta</em>, a passionate photographer who finds inspiration in capturing the fleeting beauty of life.' ) ); ?></h1>
+	<!-- wp:heading {"level":1,"align":"wide","style":{"typography":{"lineHeight":"1.2"}},"fontSize":"xx-large"} -->
+	<h1 class="wp-block-heading alignwide has-xx-large-font-size" style="line-height:1.2"><?php echo wp_kses_post( __( 'I’m <em>Leia Acosta</em>, a passionate photographer who finds inspiration in capturing the fleeting beauty of life.' ) ); ?></h1>
 	<!-- /wp:heading -->
 </div>
 <!-- /wp:group -->

--- a/patterns/offset-grid-image-posts.php
+++ b/patterns/offset-grid-image-posts.php
@@ -29,7 +29,7 @@
 			</div>
 			<!-- /wp:spacer -->
 
-			<!-- wp:query {"query":{"perPage":"3","pages":0,"offset":"3","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+			<!-- wp:query {"query":{"perPage":"3","pages":0,"offset":"3","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false}} -->
 			<div class="wp-block-query">
 				<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"default"}} -->
 				<!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"bottom":"0","top":"0"}}}} /-->
@@ -46,7 +46,7 @@
 
 		<!-- wp:column {"style":{"spacing":{"blockGap":"0"}}} -->
 		<div class="wp-block-column">
-			<!-- wp:query {"query":{"perPage":"3","pages":0,"offset":"6","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+			<!-- wp:query {"query":{"perPage":"3","pages":0,"offset":"6","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false}} -->
 			<div class="wp-block-query">
 				<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"default"}} -->
 				<!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
@@ -63,7 +63,7 @@
 			</div>
 			<!-- /wp:spacer -->
 
-			<!-- wp:query {"query":{"perPage":"3","pages":0,"offset":"9","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+			<!-- wp:query {"query":{"perPage":"3","pages":0,"offset":"9","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false}} -->
 			<div class="wp-block-query">
 				<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"default"}} -->
 				<!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} /-->


### PR DESCRIPTION
**Description**

Fixes #657, updated the group and headline to correctly align the heading.

In addition, this fixes an issue with a sticky post being shown in all four columns if one post is set to sticky.

**Screenshots**

The template before, with the sticky post (the blue one at top) being shown in all columns:
<img width="1312" alt="CleanShot 2023-10-16 at 17 28 40@2x" src="https://github.com/WordPress/twentytwentyfour/assets/7585600/6384a137-d9ad-45dd-8229-1fcab8119924">

After, only the left column allows sticky posts:
<img width="1318" alt="CleanShot 2023-10-16 at 17 31 57@2x" src="https://github.com/WordPress/twentytwentyfour/assets/7585600/71f8052f-9dcc-4082-92b2-d2e02a6902c0">


**Testing Instructions**

1. Open the Site Editor
2. Choose the "Blog Home" template
3. Open the panel to "Replace template" (same as "Clear customizations")
4. Choose Portfolio Home template
