### PR TITLE
Fix footer column alignment

### DIFF
--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -32,7 +32,7 @@
 
 		<!-- wp:column {"width":"50%"} -->
 		<div class="wp-block-column" style="flex-basis:50%">
-			<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+			<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between","verticalAlignment":"top"}} -->
 			<div class="wp-block-group">
 				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 				<div class="wp-block-group">


### PR DESCRIPTION
**Description**

Fixes #658 by giving the top align to the row group block containing all three "columns" (they're actually group blocks).

**Screenshots**

<img width="1375" alt="CleanShot 2023-10-16 at 17 45 57@2x" src="https://github.com/WordPress/twentytwentyfour/assets/7585600/d2b88339-7a09-4eb2-8fa5-9bd70043f6ca">

**Testing Instructions**

1. Check out PR
2. Open site editor
3. Go to a page/template with this footer
4. Add one link to any of the columns
5. All columns should be aligned to the top
