### PR TITLE
Adding sans-serif and serif system fonts

### DIFF
--- a/styles/ember.json
+++ b/styles/ember.json
@@ -149,6 +149,16 @@
 					"fontFamily": "\"Jost\", sans-serif",
 					"name": "Jost",
 					"slug": "heading"
+				},
+				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif",
+					"name": "System Sans-serif",
+					"slug": "system-sans-serif"
+				},
+				{
+					"fontFamily": "Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+					"name": "System Serif",
+					"slug": "system-serif"
 				}
 			]
 		}

--- a/styles/fossil.json
+++ b/styles/fossil.json
@@ -141,6 +141,16 @@
 					"fontFamily": "Cardo",
 					"name": "Cardo",
 					"slug": "body"
+				},
+				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif",
+					"name": "System Sans-serif",
+					"slug": "system-sans-serif"
+				},
+				{
+					"fontFamily": "Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+					"name": "System Serif",
+					"slug": "system-Serif"
 				}
 			],
 			"fontSizes": [

--- a/styles/fossil.json
+++ b/styles/fossil.json
@@ -150,7 +150,7 @@
 				{
 					"fontFamily": "Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
 					"name": "System Serif",
-					"slug": "system-Serif"
+					"slug": "system-serif"
 				}
 			],
 			"fontSizes": [

--- a/styles/ice.json
+++ b/styles/ice.json
@@ -139,9 +139,14 @@
 					"slug": "body"
 				},
 				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif",
+					"name": "System Sans-serif",
+					"slug": "system-sans-serif"
+				},
+				{
 					"fontFamily": "Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
 					"name": "System Serif",
-					"slug": "system-Serif"
+					"slug": "system-serif"
 				}
 			],
 			"fontSizes": [

--- a/styles/ice.json
+++ b/styles/ice.json
@@ -137,6 +137,11 @@
 					"fontFamily": "\"Jost\", sans-serif",
 					"name": "Jost",
 					"slug": "body"
+				},
+				{
+					"fontFamily": "Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+					"name": "System Serif",
+					"slug": "system-Serif"
 				}
 			],
 			"fontSizes": [

--- a/styles/maelstrom.json
+++ b/styles/maelstrom.json
@@ -84,6 +84,16 @@
 					"fontFamily": "\"Jost\", sans-serif",
 					"name": "Jost",
 					"slug": "heading"
+				},
+				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif",
+					"name": "System Sans-serif",
+					"slug": "system-sans-serif"
+				},
+				{
+					"fontFamily": "Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+					"name": "System Serif",
+					"slug": "system-serif"
 				}
 			],
 			"fontSizes": [

--- a/styles/mint.json
+++ b/styles/mint.json
@@ -83,6 +83,16 @@
 					"fontFamily": "\"Jost\", sans-serif",
 					"name": "Jost",
 					"slug": "body"
+				},
+				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif",
+					"name": "System Sans-serif",
+					"slug": "system-sans-serif"
+				},
+				{
+					"fontFamily": "Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+					"name": "System Serif",
+					"slug": "system-Serif"
 				}
 			]
 		}

--- a/styles/mint.json
+++ b/styles/mint.json
@@ -92,7 +92,7 @@
 				{
 					"fontFamily": "Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
 					"name": "System Serif",
-					"slug": "system-Serif"
+					"slug": "system-serif"
 				}
 			]
 		}

--- a/theme.json
+++ b/theme.json
@@ -243,6 +243,16 @@
 					"fontFamily": "Cardo",
 					"name": "Cardo",
 					"slug": "heading"
+				},
+				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif",
+					"name": "System Sans-serif",
+					"slug": "system-sans-serif"
+				},
+				{
+					"fontFamily": "Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+					"name": "System Serif",
+					"slug": "system-Serif"
 				}
 			],
 			"fontSizes": [


### PR DESCRIPTION
**Description**

This PR adds sans-serif and serif system fonts to the typography section. It has to be added to every style variation that changes the typography setup from the main `theme.json`.

A system font stack is a lightweight alternative to the provided fonts that the theme is designed with.

Alternative to #573, #590, #591.

**Screenshots**

<img width="252" alt="CleanShot 2023-10-16 at 18 37 02@2x" src="https://github.com/WordPress/twentytwentyfour/assets/7585600/e95541b5-1f5c-4e11-a5f4-f29dfb752451">

**Testing Instructions**

1. Check out PR
2. Go to site editor
3. Open any template
4. Select some text
5. Check typography / font family settings

Alternative:
1. Go to global styles
2. Open Typography section
3. See the fonts listed as in the screenshot above