### PR TITLE
Remove page template type from templates without post-content

### DIFF
--- a/patterns/template-home-blogging.php
+++ b/patterns/template-home-blogging.php
@@ -2,7 +2,7 @@
 /**
  * Title: Blogging home template
  * Slug: twentytwentyfour/template-home-blogging
- * Template Types: front-page, index, home, page
+ * Template Types: front-page, index, home
  * Viewport width: 1400
  * Inserter: no
  */

--- a/patterns/template-home-portfolio.php
+++ b/patterns/template-home-portfolio.php
@@ -2,7 +2,7 @@
 /**
  * Title: Portfolio home template with post featured images
  * Slug: twentytwentyfour/template-home-portfolio
- * Template Types: front-page, index, home, page
+ * Template Types: front-page, index, home
  * Viewport width: 1400
  * Inserter: no
  */


### PR DESCRIPTION
**Description**

These should not be suggested as "page" templates when creating alternate page templates, as they do not have core/post-content to make them editable within the pages admin views. 
