### PR TITLE
Update text-faq.php — matching <hr> border color with details block b…

### DIFF
--- a/patterns/text-faq.php
+++ b/patterns/text-faq.php
@@ -16,8 +16,8 @@
 
 	<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-group alignwide">
-		<!-- wp:separator {"style":{"color":{"background":"#ffffff1a"}},"className":"is-style-wide"} -->
-		<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background is-style-wide" style="background-color:#ffffff1a;color:#ffffff1a" />
+		<!-- wp:separator {"backgroundColor":"contrast-2","className":"is-style-wide"} -->
+		<hr class="wp-block-separator has-text-color has-contrast-2-color has-alpha-channel-opacity has-contrast-2-background-color has-background is-style-wide"/>
 		<!-- /wp:separator -->
 
 		<!-- wp:details {"style":{"spacing":{"margin":{"top":"0"}}},"className":"is-style-arrow-icon-details","fontSize":"medium"} -->


### PR DESCRIPTION
Updated the border color.

The color of the `<hr>` element was slightly off. 

The updated version matches the background with the border color of the details block using the `contrast-2` color variable. This also now matches across all style variations.

![Screenshot 2023-10-20 at 22 06 44](https://github.com/WordPress/twentytwentyfour/assets/3746751/53320b80-c9b7-44f4-a714-5cd84b711a7a)
