### PR TITLE
Update class for pricing table

### DIFF
--- a/patterns/cta-pricing.php
+++ b/patterns/cta-pricing.php
@@ -32,7 +32,7 @@
 			<!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|30","left":"var:preset|spacing|30","top":"var:preset|spacing|30","bottom":"var:preset|spacing|10"}},"border":{"top":{"color":"var:preset|color|base-3","width":"1px"}}}} -->
 			<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--base-3);border-top-width:1px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--30)">
 				<!-- wp:heading {"textAlign":"center","level":4,"style":{"spacing":{"padding":{"top":"1px"}}},"fontSize":"medium"} -->
-				<h4 class="wp-block-heading has-text-align-center has-medium-font-size" style="padding-top:1px">
+				<h4 class="wp-block-heading has-text-align-center has-medium-font-size">
 					<em><?php echo esc_html_x( 'Free', 'Sample heading for the first pricing level', 'twentytwentyfour' ); ?></em>
 				</h4>
 				<!-- /wp:heading -->
@@ -94,7 +94,7 @@
 			<!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|30","left":"var:preset|spacing|30","top":"var:preset|spacing|30","bottom":"var:preset|spacing|10"}},"border":{"top":{"color":"var:preset|color|contrast","width":"2px"}}}} -->
 			<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--contrast);border-top-width:2px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--30)">
 				<!-- wp:heading {"textAlign":"center","level":4} -->
-				<h4 class="wp-block-heading has-text-align-center">
+				<h4 class="wp-block-heading has-text-align-center has-medium-font-size">
 					<em><?php echo esc_html_x( 'Connoisseur', 'Sample heading for the second pricing level', 'twentytwentyfour' ); ?></em>
 				</h4>
 				<!-- /wp:heading -->
@@ -152,7 +152,7 @@
 			<!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|30","left":"var:preset|spacing|30","top":"var:preset|spacing|30","bottom":"var:preset|spacing|10"}},"border":{"top":{"color":"var:preset|color|base-3","width":"1px"}}}} -->
 			<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--base-3);border-top-width:1px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--30)">
 				<!-- wp:heading {"textAlign":"center","level":4,"style":{"spacing":{"padding":{"top":"1px"}}},"fontSize":"medium"} -->
-				<h4 class="wp-block-heading has-text-align-center has-medium-font-size" style="padding-top:1px">
+				<h4 class="wp-block-heading has-text-align-center has-medium-font-size">
 					<em><?php echo esc_html_x( 'Expert', 'Sample heading for the third pricing level', 'twentytwentyfour' ); ?></em>
 				</h4>
 				<!-- /wp:heading -->


### PR DESCRIPTION
Adjust 'Connoisseur' class to be consistent with 'Free' and 'Expert'.

**Description**
The middle plan 'Connoisseur' is misaligned due to using a different class than the adjacent two plans. This seems not to add any value, other than slightly distorting the pricing tables alignment, which in my opinion doesn't improve the design. The tab is already highlighted with the separator above showing as bold. I have also removed the unused 1px padding.

Fixes #694 
<!-- Describe the purpose or reason for the pull request -->

**Screenshots**

<!-- Add screenshots of the change, if applicable -->
Before
<img width="1304" alt="Screenshot 2566-10-24 at 13 19 20" src="https://github.com/WordPress/twentytwentyfour/assets/38789408/b442abc7-f442-46e3-8685-09dc69f84a06">


After - Alignment fixed.
<img width="1220" alt="Screenshot 2566-10-24 at 13 30 39" src="https://github.com/WordPress/twentytwentyfour/assets/38789408/cded57f1-36ee-4ee2-a354-0b839121388b">

**Testing Instructions**

1. Visit http://2024.wordpress.net/index.php/pricing/
2. See pricing table.

**Contributors**
<!-- Please ensure anyone who contributed on linked issues and within this pull request have _AT LEAST_ their GitHub Username listed in the `CONTRIBUTORS.md` file as part of this PR. -->
