### PR TITLE
Capitalization Consistency

### DIFF
--- a/patterns/text-feature-grid-3-col.php
+++ b/patterns/text-feature-grid-3-col.php
@@ -35,7 +35,7 @@
 		<!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 		<div class="wp-block-column">
 			<!-- wp:heading {"textAlign":"left","level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"is-style-asterisk","fontSize":"medium","fontFamily":"body"} -->
-			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Renovation and restoration', 'Sample feature heading', 'twentytwentyfour' ); ?></h3>
+			<h3 class="wp-block-heading has-text-align-left is-style-asterisk has-body-font-family has-medium-font-size" style="font-style:normal;font-weight:600"><?php echo esc_html_x( 'Renovation and Restoration', 'Sample feature heading', 'twentytwentyfour' ); ?></h3>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"align":"left"} -->


### PR DESCRIPTION
In this PR, I've made a revision to maintain a consistent capitalization style within the section headings. The headings "Continuous Support," "App Access," "Consulting," and "Project Management" originally utilized title case, while "Renovation and restoration" was in sentence case. 

I've harmonized the capitalization style by updating to "Renovation and Restoration".

**Description**

<!-- Describe the purpose or reason for the pull request -->
Maintain a consistent capitilization style.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

**Testing Instructions**

<!-- Provide steps for testing -->
1. Visit http://2024.wordpress.net/index.php/entrepreneur-demo/
2. Scroll to the section titled: A passion for creating spaces

**Contributors**

<!-- Please ensure anyone who contributed on linked issues and within this pull request have _AT LEAST_ their GitHub Username listed in the `CONTRIBUTORS.md` file as part of this PR. -->
