### PR TITLE
Add a blog template, rename blog to front-page

### DIFF
--- a/templates/front-page.html
+++ b/templates/front-page.html
@@ -1,0 +1,1 @@
+<!-- wp:pattern {"slug":"twentytwentyfour/template-home"} /-->

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,1 +1,1 @@
-<!-- wp:pattern {"slug":"twentytwentyfour/template-home"} /-->
+<!-- wp:pattern {"slug":"twentytwentyfour/template-home-blogging"} /-->


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

This is an alternative to https://github.com/WordPress/twentytwentyfour/pull/706

I state my concerns [here](https://github.com/WordPress/twentytwentyfour/pull/706#issuecomment-1784710548). I opt for this solution that maintains the spirit of the theme while making the home template a true blogging one, even if by default the main page is a static one, which is what this theme intends to do. 

The user can still swap the front-page template to use one of the other 2 patterns that do contain a query block that inherits the query from the page they want that. 

If a user wants to create a page and assign blog posts to it, it will use the new home.html template, that has the blogging template on it.
