### PR TITLE
Remove index as from unrelated templates

### DIFF
--- a/patterns/template-home-business.php
+++ b/patterns/template-home-business.php
@@ -2,7 +2,7 @@
 /**
  * Title: Business home template
  * Slug: twentytwentyfour/template-home
- * Template Types: front-page, index, home
+ * Template Types: front-page, home
  * Viewport width: 1400
  * Inserter: no
  */

--- a/patterns/template-home-portfolio.php
+++ b/patterns/template-home-portfolio.php
@@ -2,7 +2,7 @@
 /**
  * Title: Portfolio home template with post featured images
  * Slug: twentytwentyfour/template-home-portfolio
- * Template Types: front-page, index, home
+ * Template Types: front-page, home
  * Viewport width: 1400
  * Inserter: no
  */


### PR DESCRIPTION
**Description**
Better surface the right templates in the right areas, instead of a wholesale approach. This reduces the confusion of switching between blog templates on the "Index" template. Surfaced while reviewing #706. 

**Screenshots**

Before: 
![CleanShot 2023-10-30 at 11 15 39](https://github.com/WordPress/twentytwentyfour/assets/1813435/7cc22359-efdb-4358-9936-8b04c981ba3c)

After: 
![CleanShot 2023-10-30 at 11 14 49](https://github.com/WordPress/twentytwentyfour/assets/1813435/9cccea88-5698-42b2-9b22-186219f94fa4)


**Testing Instructions**

<!-- Provide steps for testing -->
1. Activate the theme.
2. Go to the index template.
3. Open the Template inspector. 
4. Click on the vertical ellipsis. 
5. Click on "Replace template". 
6. See changes. 
