### PR TITLE
Rely on parent theme data for block style

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -32,9 +32,9 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 			'core/button',
 			array(
 				'handle' => 'twentytwentyfour-button-style-outline',
-				'src'    => get_theme_file_uri( 'assets/css/button-outline.css' ),
-				'ver'    => wp_get_theme( 'twentytwentyfour' )->get( 'Version' ),
-				'path'   => get_theme_file_path( 'assets/css/button-outline.css' ),
+				'src'    => get_parent_theme_file_uri( 'assets/css/button-outline.css' ),
+				'ver'    => wp_get_theme( get_template() )->get( 'Version' ),
+				'path'   => get_parent_theme_file_path( 'assets/css/button-outline.css' ),
 			)
 		);
 


### PR DESCRIPTION
See https://github.com/WordPress/wordpress-develop/pull/5593#discussion_r1376631929:

> the version always comes from TT4, while the actual `button-outline.css` file _may_ be loaded from a TT4 child theme. If we want to force that file to always be that of TT4 (which I'd argue is probably the safer call), we should replace the two `get_theme_file_*()` function calls with their equivalent `get_parent_theme_file_*()` calls. That way this functionality is consistent and will always rely on the styles from TT4, ignoring any child theme. I'd argue that makes sense here because the block styles registered below can't be overwritten by a child theme either.

This PR addresses the logic so that it always relies on the parent theme data (which will always be TT4, since it cannot be used as a child theme). It's mostly a consistency fix, which ensures we don't accidentally allow child themes to override this while then still relying on the parent theme version for it.

Given the other block styles below can't be overwritten by the child theme, I think allowing that here was mostly by accident.