### PR TITLE
Separate outline css to its own function

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -20,23 +20,6 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 	 * @return void
 	 */
 	function twentytwentyfour_block_styles() {
-		/**
-		 * The wp_enqueue_block_style() function allows us to enqueue a stylesheet
-		 * for a specific block. These will only get loaded when the block is rendered
-		 * (both in the editor and on the front end), improving performance
-		 * and reducing the amount of data requested by visitors.
-		 *
-		 * See https://make.wordpress.org/core/2021/12/15/using-multiple-stylesheets-per-block/ for more info.
-		 */
-		wp_enqueue_block_style(
-			'core/button',
-			array(
-				'handle' => 'twentytwentyfour-button-style-outline',
-				'src'    => get_parent_theme_file_uri( 'assets/css/button-outline.css' ),
-				'ver'    => wp_get_theme( get_template() )->get( 'Version' ),
-				'path'   => get_parent_theme_file_path( 'assets/css/button-outline.css' ),
-			)
-		);
 
 		register_block_style(
 			'core/details',
@@ -163,6 +146,40 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 endif;
 
 add_action( 'init', 'twentytwentyfour_block_styles' );
+
+/**
+ * Enqueue block stylesheets.
+ */
+
+ if ( ! function_exists( 'twentytwentyfour_block_stylesheets' ) ) :
+	/**
+	 * Enqueue custom block stylesheets
+	 *
+	 * @since Twenty Twenty-Four 1.0
+	 * @return void
+	 */
+	function twentytwentyfour_block_stylesheets() {
+		/**
+		 * The wp_enqueue_block_style() function allows us to enqueue a stylesheet
+		 * for a specific block. These will only get loaded when the block is rendered
+		 * (both in the editor and on the front end), improving performance
+		 * and reducing the amount of data requested by visitors.
+		 *
+		 * See https://make.wordpress.org/core/2021/12/15/using-multiple-stylesheets-per-block/ for more info.
+		 */
+		wp_enqueue_block_style(
+			'core/button',
+			array(
+				'handle' => 'twentytwentyfour-button-style-outline',
+				'src'    => get_parent_theme_file_uri( 'assets/css/button-outline.css' ),
+				'ver'    => wp_get_theme( get_template() )->get( 'Version' ),
+				'path'   => get_parent_theme_file_path( 'assets/css/button-outline.css' ),
+			)
+		);
+	}
+endif;
+
+add_action( 'init', 'twentytwentyfour_block_stylesheets' );
 
 /**
  * Register pattern categories.

--- a/functions.php
+++ b/functions.php
@@ -151,7 +151,7 @@ add_action( 'init', 'twentytwentyfour_block_styles' );
  * Enqueue block stylesheets.
  */
 
- if ( ! function_exists( 'twentytwentyfour_block_stylesheets' ) ) :
+if ( ! function_exists( 'twentytwentyfour_block_stylesheets' ) ) :
 	/**
 	 * Enqueue custom block stylesheets
 	 *


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->
While presenting the theme yesterday during developer hours I noticed that we are putting on the same function the registering of block styles and the enqueueing of the stylesheet for the outline block style. While the end result is similar in nature, I think it can be confusing for users that want to learn from TT4, so they are best separated into two different functions. 