### PR TITLE
Fix height of newsletter landing pattern

### DIFF
--- a/patterns/page-newsletter-landing.php
+++ b/patterns/page-newsletter-landing.php
@@ -10,8 +10,8 @@
  */
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"},"margin":{"top":"0","bottom":"0"}},"dimensions":{"minHeight":"100vw"}},"backgroundColor":"accent-3","layout":{"type":"flex","orientation":"vertical","justifyContent":"center","verticalAlignment":"center"}} -->
-<div class="wp-block-group alignfull has-accent-3-background-color has-background" style="min-height:100vw;margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)">
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"},"margin":{"top":"0","bottom":"0"}},"dimensions":{"minHeight":"100vh"}},"backgroundColor":"accent-3","layout":{"type":"flex","orientation":"vertical","justifyContent":"center","verticalAlignment":"center"}} -->
+<div class="wp-block-group alignfull has-accent-3-background-color has-background" style="min-height:100vh;margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)">
 	<!-- wp:group {"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
 		<!-- wp:image {"align":"center","width":"45px","height":"49px","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

We were using vw units instead of vh for the min-height on this pattern, this fixes it.

Before:

<img width="2135" alt="Screenshot 2023-11-03 at 16 42 24" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/cfb1f696-f838-4e6c-8dc8-5ad960a520b6">


After:


<img width="2149" alt="Screenshot 2023-11-03 at 16 42 32" src="https://github.com/WordPress/twentytwentyfour/assets/3593343/64bef8b4-e964-4ca6-83a7-fccb91e86317">