### PR TITLE
Remove custom CSS for links

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -785,7 +785,6 @@
 			"background": "var(--wp--preset--color--base)",
 			"text": "var(--wp--preset--color--contrast)"
 		},
-		"css": "a{text-decoration-thickness:0.0625em;text-underline-offset: 0.15em}",
 		"elements": {
 			"button": {
 				":active": {


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->
Closes https://github.com/WordPress/twentytwentyfour/issues/716

This CSS is not applied consistently and it's hard to know where to override it, while not being too much of a design impact, so let's remove it for simplicity.