### PR TITLE
Update Readme with archive info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# Archived repository
+
+**This theme has been merged into the WordPress Core SVN repository, and is no longer maintained on GitHub.**
+
+**Tickets to report bugs or make feature requests can be [opened against the Bundled Themes component](https://core.trac.wordpress.org/newticket?component=Bundled+Theme) on trac.**
+
+**Browse open issues: https://core.trac.wordpress.org/search?q=twenty+twenty-four.**
+
+---
+
 # Twenty Twenty-Four
 
 Welcome to the development repository for the default theme that will launch with [WordPress 6.4](https://make.wordpress.org/core/6-4/).
@@ -10,7 +20,7 @@ You can view a demo of this theme at [2024.wordpress.net](https://2024.wordpress
 
 ## Contributing
 
-If you would like to contribute code, the list of [open issues](https://github.com/WordPress/twentytwentyfour/issues) is a great place to start looking for tasks — but contributing is not just for developers. There are many opportunities to help with testing, triage, discussion, design, building [patterns](https://github.com/WordPress/twentytwentyfour/issues?q=is%3Aissue+is%3Aopen+label%3A%22%5BComponent%5D+Block+Patterns%22) and templates, and more. 
+If you would like to contribute code, the list of [open issues](https://core.trac.wordpress.org/search?q=twenty+twenty-four) is a great place to start looking for tasks — but contributing is not just for developers. There are many opportunities to help with testing, triage, discussion, design, building patterns and templates, and more. 
 
 If you'd like to help with triage, let @luminuu and @MaggieCabrera know in [WordPress.org's Slack instance](https://make.wordpress.org/chat/). We'll help you get set up with the ability to add labels to issues and PRs.
 


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Updates the readme to prepare for the archiving of the repository now the theme has been merged in to WordPress Core.

The changes are largely based on the equivalent commit for TT3, https://github.com/WordPress/twentytwentythree/commit/11440a5b38bae6882fc2c00b703d4bb95420a0f5 

**Screenshots**

N/A

**Testing Instructions**

N/A

**Contributors**

<!-- Please ensure anyone who contributed on linked issues and within this pull request have _AT LEAST_ their GitHub Username listed in the `CONTRIBUTORS.md` file as part of this PR. -->
