### PR TITLE
Fix system-serif slug type-o

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -247,7 +247,7 @@
 				{
 					"fontFamily": "Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
 					"name": "System Serif",
-					"slug": "system-Serif"
+					"slug": "system-serif"
 				}
 			],
 			"fontSizes": [


### PR DESCRIPTION
**Description**

When trying the set, for example, the global headings font family to System Serif, the global style setting will be converted to style rule `font-family: var(--wp--preset--font-family--system-Serif);` (notice the upper case S) referencing a non-existent root variable.

**Testing Instructions**

1. Go to global style settings and change the Headings font face to System Serif.
2. Save styles.
3. Verify any headings on the front end: they will be using the browser default, not the root `--wp--preset--font-family--system-serif` (notice the lower case S) value.
