### PR TITLE
Wrap Navigation block in Row within the header.html template part

### DIFF
--- a/parts/header.html
+++ b/parts/header.html
@@ -15,7 +15,11 @@
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}}} /-->
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+		<div class="wp-block-group">
+			<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}}} /-->
+		</div>
+		<!-- /wp:group -->
 	</div>
 	<!-- /wp:group -->
 </div>

--- a/parts/header.html
+++ b/parts/header.html
@@ -15,7 +15,7 @@
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
 		<div class="wp-block-group">
 			<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}}} /-->
 		</div>


### PR DESCRIPTION
**Description**

<!-- Describe the purpose or reason for the pull request -->

Now that the Block Hooks API has been released as part of WordPress 6.4 3PDs may want to insert their own blocks into the header, specifically _after_ the Navigation block. This currently causes problems because the Navigation block and it's siblings are treated as flex items due to its parent being a Row block.

This PR wraps the Navigation block within a Row block of its own. By default the behaviour of the header should remain the same and introduce no regressions but this now means plugins are able to use the Block Hooks API to automatically insert their own blocks using the Navigation as an anchor block without them being treated as flex items (e.g. Mini Cart or My Account blocks)

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

**Testing Instructions**

1. Activate the theme on this branch
2. Ensure that the header behaves the same on various viewport sizes and no regressions have been introduced by this change.

**Contributors**

<!-- Please ensure anyone who contributed on linked issues and within this pull request have _AT LEAST_ their GitHub Username listed in the `CONTRIBUTORS.md` file as part of this PR. -->
